### PR TITLE
refactor: replace Azure OpenAI LLM opponent with Ollama (local + cloud)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
-# Azure OpenAI (GPT-4.1) credentials for the LLM opponent.
-# Copy to .env and fill in. The base URL embeds the deployment name; the client
-# appends /chat/completions?api-version=<AZURE_OPENAI_API_VERSION>.
-AZURE_OPENAI_BASE_URL=https://<resource>.api.cognitive.microsoft.com/openai/deployments/gpt-4.1
-AZURE_OPENAI_API_VERSION=2024-12-01-preview
-AZURE_OPENAI_API_KEY=your-azure-openai-api-key
+# Ollama configuration for the LLM opponent. Copy to .env and edit if needed.
+#
+# LOCAL (free, no key): leave these defaults. The client talks to a local Ollama
+# at http://localhost:11434/v1. Pull a model first, e.g.:
+#   ollama pull gpt-oss:20b
+#
+# CLOUD (Ollama Turbo, hosted big models): point the base URL at ollama.com and
+# set your key. Used for training against gpt-oss:120b without local GPU/RAM:
+#   OLLAMA_BASE_URL=https://ollama.com/v1
+#   OLLAMA_API_KEY=your-ollama-api-key
+
+OLLAMA_BASE_URL=http://localhost:11434/v1
+OLLAMA_API_KEY=ollama

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Research question:** What is the best strategy to win at Risiko (Risk)?
 
-This project trains a PPO agent to discover optimal Risiko strategy purely through self-play and games against an Azure OpenAI GPT-4.1 LLM opponent.
+This project trains a PPO agent to discover optimal Risiko strategy purely through self-play and games against an Ollama-served LLM opponent — run locally for free or against a hosted big model (e.g. `gpt-oss:120b`) on Ollama Cloud.
 
 ---
 
@@ -16,28 +16,35 @@ Python 3.12+ required. PyTorch and all dependencies are pinned in `requirements.
 
 ---
 
-## Azure OpenAI setup
+## Ollama setup
 
-The LLM opponent calls **Azure OpenAI (GPT-4.1)** via the `/chat/completions` endpoint with a `response_format` JSON schema (`strict: true`) that constrains the reply to `{"action_index": <int>}` — an index into the legal-action list, so the chosen move is legal by construction and the response is ~10 tokens.
+The LLM opponent calls **Ollama** via the OpenAI-compatible `/v1/chat/completions` endpoint with a `response_format` JSON schema (`strict: true`) that constrains the reply to `{"action_index": <int>}` — an index into the legal-action list, so the chosen move is legal by construction and the response is tiny.
 
-Credentials live in a git-ignored `.env` at the project root. Copy the template and fill it in:
+One client serves both modes; they differ only in `base_url`, key, and model:
+
+**Local (free, no key):** install [Ollama](https://ollama.com), pull a model, and you're done — no `.env` needed (the client defaults to `http://localhost:11434/v1`).
+
+```bash
+ollama pull gpt-oss:20b
+```
+
+**Cloud (Ollama Turbo, hosted big models like `gpt-oss:120b`):** copy the template and set your key:
 
 ```bash
 cp .env.example .env
-# then edit .env with your Azure resource values
+# then set OLLAMA_BASE_URL=https://ollama.com/v1 and OLLAMA_API_KEY=<your key>
 ```
 
-`src/utils/env.py:ensure_env_loaded()` loads it once per process (called by the CLI; lazily by the client). Auth uses the `api-key` header.
+`src/utils/env.py:ensure_env_loaded()` loads `.env` once per process (called by the CLI; lazily by the client). Auth uses the standard `Authorization: Bearer <key>` header. Local serving ignores the key, so any placeholder works.
 
 ---
 
-## Required environment variables
+## Environment variables (optional — only for cloud)
 
 | Variable | Example | Purpose |
 |---|---|---|
-| `AZURE_OPENAI_BASE_URL` | `https://<resource>.api.cognitive.microsoft.com/openai/deployments/gpt-4.1` | Resource + deployment URL; the client appends `/chat/completions?api-version=...` |
-| `AZURE_OPENAI_API_VERSION` | `2024-12-01-preview` | API version query parameter |
-| `AZURE_OPENAI_API_KEY` | `your-azure-openai-api-key` | Sent as the `api-key` request header |
+| `OLLAMA_BASE_URL` | `https://ollama.com/v1` (cloud) / `http://localhost:11434/v1` (local, default) | OpenAI-compatible base URL; the client appends `/chat/completions` |
+| `OLLAMA_API_KEY` | `your-ollama-api-key` | Sent as `Authorization: Bearer <key>`; ignored by local serving |
 
 `LLMOpponent` enforces a hard 30 s timeout per move via a `ThreadPoolExecutor` and falls back to a `RandomAgent` on any timeout, HTTP error, parse error, or out-of-range index — the returned action is always legal.
 
@@ -147,14 +154,14 @@ Win rates at 6 players (random baseline ≈ 1/6 ≈ 16.7%):
 | Agent | Win rate | Notes |
 |---|---|---|
 | Random | ≈ 16% | Uniform action sampling |
-| LLM (GPT-4.1) | ≈ 25–35% | Zero-shot tactical reasoning |
+| LLM (gpt-oss) | ≈ 25–35% | Zero-shot tactical reasoning |
 | PPO (target) | > 35% | Self-play + LLM curriculum |
 
 ---
 
 ## Six-player LLM profiles
 
-Defined in `config/default_6p.yaml`. Each slot uses GPT-4.1 with a distinct `temperature`/`top_p` and a strategy hint injected into the prompt.
+Defined in `config/default_6p.yaml`. Each slot uses `gpt-oss:120b` (override per slot via the `model` field) with a distinct `temperature`/`top_p` and a strategy hint injected into the prompt.
 
 | Player | Temp | Top-p | Strategy hint |
 |---|---|---|---|

--- a/config/default_6p.yaml
+++ b/config/default_6p.yaml
@@ -2,34 +2,34 @@
   temperature: 0.1
   top_p: 0.9
   strategy_hint: "Play greedily: maximise territory gain each turn."
-  model: gpt-4.1
+  model: gpt-oss:120b
 
 - player_id: 1
   temperature: 0.4
   top_p: 0.9
   strategy_hint: "Focus on securing full continents before expanding."
-  model: gpt-4.1
+  model: gpt-oss:120b
 
 - player_id: 2
   temperature: 0.7
   top_p: 0.85
   strategy_hint: "Eliminate the weakest player early; control cards."
-  model: gpt-4.1
+  model: gpt-oss:120b
 
 - player_id: 3
   temperature: 0.3
   top_p: 0.95
   strategy_hint: "Fortify borders and expand only when safe."
-  model: gpt-4.1
+  model: gpt-oss:120b
 
 - player_id: 4
   temperature: 0.9
   top_p: 0.8
   strategy_hint: "Play unpredictably; avoid predictable attack patterns."
-  model: gpt-4.1
+  model: gpt-oss:120b
 
 - player_id: 5
   temperature: 0.5
   top_p: 0.9
   strategy_hint: "Balance attack and defence; trade cards conservatively."
-  model: gpt-4.1
+  model: gpt-oss:120b

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "typer>=0.15.0",
     "pyyaml>=6.0",
     "httpx>=0.28.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [project.optional-dependencies]
@@ -42,6 +43,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.12",
+    "hypothesis>=6.0.0",
     "playwright>=1.59.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ pytest-cov>=7.1.0
 ruff>=0.15.12
 hypothesis>=6.0.0
 
-# Azure OpenAI HTTP client + .env loading
+# Ollama HTTP client (local or cloud) + .env loading
 httpx>=0.28.0
 python-dotenv>=1.0.0
 

--- a/src/agents/llm_opponent.py
+++ b/src/agents/llm_opponent.py
@@ -1,4 +1,4 @@
-"""LLM-based opponent backed by Azure OpenAI, with timeout and random fallback."""
+"""LLM-based opponent backed by Ollama (local or cloud), with timeout and random fallback."""
 
 from __future__ import annotations
 
@@ -10,19 +10,19 @@ import httpx
 import numpy as np
 import torch
 
-from src.agents.azure_openai import call_azure_for_action_index
 from src.agents.base import Agent
+from src.agents.ollama_client import call_ollama_for_action_index
 from src.agents.player_config import PlayerConfig
 from src.agents.random_agent import RandomAgent
 from src.utils.log import get_logger
 
 logger = get_logger("llm_opponent")
 
-DEFAULT_MODEL = "gpt-4.1"
+DEFAULT_MODEL = "gpt-oss:120b"
 
 
 class LLMOpponent(Agent):
-    """Agent that queries Azure OpenAI for an action, with timeout and fallback."""
+    """Agent that queries Ollama for an action, with timeout and fallback."""
 
     def __init__(
         self,
@@ -34,20 +34,19 @@ class LLMOpponent(Agent):
         strategy_hint: str | None = None,
         base_url: str | None = None,
         api_key: str | None = None,
-        api_version: str | None = None,
         player_config: PlayerConfig | None = None,
     ) -> None:
-        """Create an LLM opponent backed by Azure OpenAI.
+        """Create an LLM opponent backed by Ollama.
 
         Args:
-            model: Deployment/model name (overridden by ``player_config.model``).
+            model: Model/tag name (overridden by ``player_config.model``), e.g.
+                ``gpt-oss:20b`` (local) or ``gpt-oss:120b`` (cloud).
             timeout: Hard timeout per LLM call in seconds.
             temperature: Sampling temperature (overridden by ``player_config``).
             top_p: Nucleus sampling parameter (overridden by ``player_config``).
             strategy_hint: Prompt directive (overridden by ``player_config``).
-            base_url: Optional override for ``AZURE_OPENAI_BASE_URL``.
-            api_key: Optional override for ``AZURE_OPENAI_API_KEY``.
-            api_version: Optional override for ``AZURE_OPENAI_API_VERSION``.
+            base_url: Optional override for ``OLLAMA_BASE_URL``.
+            api_key: Optional override for ``OLLAMA_API_KEY``.
             player_config: Per-player sampling profile; takes precedence over scalars.
         """
         self._player_config = player_config
@@ -58,7 +57,6 @@ class LLMOpponent(Agent):
         self._strategy_hint = player_config.strategy_hint if player_config else strategy_hint
         self._base_url = base_url
         self._api_key = api_key
-        self._api_version = api_version
         self._fallback = RandomAgent()
 
     def act(
@@ -116,16 +114,15 @@ class LLMOpponent(Agent):
         obs: dict[str, np.ndarray],
         legal_actions: list[dict[str, int]],
     ) -> int | None:
-        """Call Azure OpenAI with a hard timeout via ThreadPoolExecutor."""
+        """Call Ollama with a hard timeout via ThreadPoolExecutor."""
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(
-                call_azure_for_action_index,
+                call_ollama_for_action_index,
                 obs,
                 legal_actions,
                 model=self._model,
                 base_url=self._base_url,
                 api_key=self._api_key,
-                api_version=self._api_version,
                 timeout=self._timeout,
                 temperature=self._temperature,
                 top_p=self._top_p,

--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -1,14 +1,27 @@
-"""Azure OpenAI chat-completions client for action selection.
+"""Ollama chat-completions client for action selection (local or cloud).
 
 The LLM is asked to pick an INDEX into the ``legal_actions`` list. Output is
-constrained to ``{"action_index": <int>}`` via Azure's structured-output
+constrained to ``{"action_index": <int>}`` via the OpenAI-compatible
 ``response_format`` (json_schema, ``strict: true``) so the reply is tiny and
 guaranteed parseable; the chosen action is always legal by construction.
 
-Endpoint shape (deployment is embedded in the base URL):
-    {AZURE_OPENAI_BASE_URL}/chat/completions?api-version={AZURE_OPENAI_API_VERSION}
+One client serves both deployment modes — they differ only in ``base_url``,
+the API key, and the model name:
 
-Auth uses the ``api-key`` header (Azure convention), not a bearer token.
+* **Local (free, no key):** ``OLLAMA_BASE_URL=http://localhost:11434/v1`` with
+  a locally pulled model (e.g. ``gpt-oss:20b``). The key is ignored by Ollama
+  but still sent as a bearer token, so any placeholder works.
+* **Cloud (Ollama Turbo):** ``OLLAMA_BASE_URL=https://ollama.com/v1`` with
+  ``OLLAMA_API_KEY=<key>`` and a hosted model (e.g. ``gpt-oss:120b``).
+
+Endpoint (OpenAI-compatible; the base URL already ends in ``/v1``):
+    {OLLAMA_BASE_URL}/chat/completions
+
+Auth uses the standard ``Authorization: Bearer <key>`` header.
+
+Note on reasoning models: ``gpt-oss`` reasons before emitting the final JSON,
+which consumes completion tokens. ``max_tokens`` is therefore sized to leave
+room for that hidden reasoning rather than the ~10-token answer alone.
 """
 
 from __future__ import annotations
@@ -27,11 +40,12 @@ from src.utils.log import get_logger
 
 _log = get_logger("llm")
 
-ENV_BASE_URL = "AZURE_OPENAI_BASE_URL"
-ENV_API_KEY = "AZURE_OPENAI_API_KEY"
-ENV_API_VERSION = "AZURE_OPENAI_API_VERSION"
+ENV_BASE_URL = "OLLAMA_BASE_URL"
+ENV_API_KEY = "OLLAMA_API_KEY"
 
-DEFAULT_API_VERSION = "2024-12-01-preview"
+DEFAULT_BASE_URL = "http://localhost:11434/v1"
+DEFAULT_API_KEY = "ollama"  # placeholder; Ollama ignores it for local serving
+DEFAULT_MAX_TOKENS = 512  # leaves headroom for gpt-oss reasoning before the JSON answer
 
 _RESPONSE_FORMAT: dict[str, Any] = {
     "type": "json_schema",
@@ -48,46 +62,48 @@ _RESPONSE_FORMAT: dict[str, Any] = {
 }
 
 
-class AzureConfigError(RuntimeError):
-    """Raised when required Azure OpenAI env vars are missing."""
-
-
-def call_azure_for_action_index(
+def call_ollama_for_action_index(
     obs: dict[str, np.ndarray],
     legal_actions: list[dict[str, int]],
     *,
     model: str,
     base_url: str | None = None,
     api_key: str | None = None,
-    api_version: str | None = None,
     timeout: float = 30.0,
     temperature: float = 0.1,
     top_p: float | None = None,
     strategy_hint: str | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
 ) -> int | None:
-    """Call Azure OpenAI and return an index into *legal_actions*, or None.
+    """Call Ollama and return an index into *legal_actions*, or None.
 
-    ``model`` is sent in the request body but Azure routes on the deployment
-    embedded in *base_url*. ``base_url`` / ``api_key`` / ``api_version`` fall back
-    to the ``AZURE_OPENAI_BASE_URL`` / ``_API_KEY`` / ``_API_VERSION`` env vars.
+    ``base_url`` / ``api_key`` fall back to the ``OLLAMA_BASE_URL`` /
+    ``OLLAMA_API_KEY`` env vars, then to ``http://localhost:11434/v1`` /
+    ``"ollama"``. Because local serving needs no real key, this never raises on
+    a missing key — point ``base_url`` at ``https://ollama.com/v1`` and set
+    ``OLLAMA_API_KEY`` to use hosted (cloud) models instead.
+
+    Args:
+        obs: Current observation dict (rendered into the prompt).
+        legal_actions: Candidate actions; the model selects one by index.
+        model: Model/tag name, e.g. ``gpt-oss:20b`` (local) or ``gpt-oss:120b`` (cloud).
+        base_url: Override for ``OLLAMA_BASE_URL`` (must end in ``/v1``).
+        api_key: Override for ``OLLAMA_API_KEY``.
+        timeout: Per-call HTTP timeout in seconds.
+        temperature: Sampling temperature.
+        top_p: Optional nucleus-sampling parameter.
+        strategy_hint: Optional directive injected into the prompt.
+        max_tokens: Completion-token ceiling (sized for reasoning headroom).
 
     Returns:
         An index in ``[0, len(legal_actions))`` chosen by the model, or ``None``
         if the model declined / returned something unparseable / out of range.
-
-    Raises:
-        AzureConfigError: If base URL or API key cannot be resolved.
     """
     if not legal_actions:
         return None
     ensure_env_loaded()
-    base = (base_url or os.environ.get(ENV_BASE_URL, "")).rstrip("/")
-    key = api_key or os.environ.get(ENV_API_KEY, "")
-    version = api_version or os.environ.get(ENV_API_VERSION) or DEFAULT_API_VERSION
-    if not base or not key:
-        raise AzureConfigError(
-            f"Set {ENV_BASE_URL} and {ENV_API_KEY} (e.g. in a project .env) to use Azure OpenAI."
-        )
+    base = (base_url or os.environ.get(ENV_BASE_URL) or DEFAULT_BASE_URL).rstrip("/")
+    key = api_key or os.environ.get(ENV_API_KEY) or DEFAULT_API_KEY
 
     prompt = render_action_prompt(obs, legal_actions, strategy_hint)
     body: dict[str, Any] = {
@@ -95,13 +111,13 @@ def call_azure_for_action_index(
         "messages": [{"role": "user", "content": prompt}],
         "response_format": _RESPONSE_FORMAT,
         "temperature": temperature,
-        "max_tokens": 64,
+        "max_tokens": max_tokens,
     }
     if top_p is not None:
         body["top_p"] = top_p
 
-    url = f"{base}/chat/completions?api-version={version}"
-    headers = {"api-key": key, "Content-Type": "application/json"}
+    url = f"{base}/chat/completions"
+    headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
     _log.debug(
         "---PROMPT--- model=%s temp=%.2f n_legal=%d\n%s",
         model,
@@ -129,12 +145,12 @@ def _parse_index(
     usage = data.get("usage", {})
     completion_tokens = usage.get("completion_tokens", 0)
     if not content:
-        _log.warning("Azure returned empty content (model=%s, %.2fs)", model, elapsed)
+        _log.warning("Ollama returned empty content (model=%s, %.2fs)", model, elapsed)
         return None
     try:
         idx = int(json.loads(content)["action_index"])
     except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
-        _log.warning("Azure reply not parseable as {action_index: int}: %s | raw=%r", e, content)
+        _log.warning("Ollama reply not parseable as {action_index: int}: %s | raw=%r", e, content)
         return None
     if 0 <= idx < len(legal_actions):
         _log.info(
@@ -147,11 +163,11 @@ def _parse_index(
         )
         return idx
     _log.warning(
-        "Azure returned out-of-range idx=%d (legal range 0..%d) — falling back",
+        "Ollama returned out-of-range idx=%d (legal range 0..%d) — falling back",
         idx,
         len(legal_actions) - 1,
     )
     return None
 
 
-__all__ = ["call_azure_for_action_index", "AzureConfigError"]
+__all__ = ["call_ollama_for_action_index", "ENV_BASE_URL", "ENV_API_KEY", "DEFAULT_BASE_URL"]

--- a/src/agents/player_config.py
+++ b/src/agents/player_config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import yaml
 
-DEFAULT_MODEL = "gpt-4.1"
+DEFAULT_MODEL = "gpt-oss:120b"
 
 
 @dataclass(frozen=True)

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -1,9 +1,10 @@
 """Lazy ``.env`` loading.
 
-Secrets (the Azure OpenAI key/endpoint) live in a git-ignored ``.env`` at the
-project root. ``ensure_env_loaded()`` populates ``os.environ`` from it exactly
-once per process; it is safe to call from any entry point (CLI, tests, library
-use) and is a no-op if python-dotenv is absent or no ``.env`` exists.
+Optional settings (the Ollama base URL / cloud API key) live in a git-ignored
+``.env`` at the project root. ``ensure_env_loaded()`` populates ``os.environ``
+from it exactly once per process; it is safe to call from any entry point (CLI,
+tests, library use) and is a no-op if python-dotenv is absent or no ``.env``
+exists. Local Ollama needs no ``.env`` at all.
 """
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Session-wide pytest setup.
+
+Typer/Rich colorize and wrap ``--help`` output based on the terminal and on
+``FORCE_COLOR``/``COLUMNS`` env vars. Under CI those defaults inject ANSI color
+codes *between* characters (so ``--override`` is split by SGR escapes around the
+two dashes) and wrap at 80 columns, which breaks plain substring assertions that
+pass on a local wide, color-free terminal.
+
+Pin a plain, wide, deterministic rendering before any test (in-process
+``CliRunner`` or ``subprocess``, which inherits ``os.environ``) runs, so CLI
+help assertions behave identically everywhere.
+"""
+
+import os
+
+# Force color OFF for both Rich (NO_COLOR) and Click (NO_COLOR / CLICOLOR).
+os.environ["NO_COLOR"] = "1"
+os.environ["CLICOLOR"] = "0"
+os.environ["TERM"] = "dumb"
+# Defeat any CI-injected color forcing.
+os.environ.pop("FORCE_COLOR", None)
+os.environ.pop("CLICOLOR_FORCE", None)
+# Wide enough that long option names/descriptions never wrap mid-token.
+os.environ["COLUMNS"] = "200"

--- a/tests/test_ac60.py
+++ b/tests/test_ac60.py
@@ -1,8 +1,8 @@
-"""Source-blind acceptance-criteria tests for issue #60 — corrected to match real APIs.
+"""Source-blind acceptance-criteria tests for issue #60 — migrated to Ollama contract.
 
 Criteria covered (oracle-verified as UNIT or T2):
   [T2]   LLM calls /chat/completions with json_schema strict output
-  [UNIT] Azure credentials in .env; .env.example committed
+  [UNIT] Ollama credentials in .env; .env.example committed
   [UNIT] LLM output is an index into legal_actions
   [UNIT] render_action_prompt() is single source of truth; no hardcoded API key
   [UNIT] Attack requires >= 2 armies in source; ADJACENCY is symmetric / 42 territories
@@ -30,10 +30,9 @@ PROJECT_ROOT = pathlib.Path(__file__).parent.parent
 _N = 42  # territory count
 _N_PLAYERS = 2
 
-_AZURE_ENV = {
-    "AZURE_OPENAI_BASE_URL": "https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-    "AZURE_OPENAI_API_KEY": "fake-api-key-abc123",
-    "AZURE_OPENAI_API_VERSION": "2024-02-01",
+_OLLAMA_ENV = {
+    "OLLAMA_BASE_URL": "http://localhost:11434/v1",
+    "OLLAMA_API_KEY": "ollama",
 }
 
 
@@ -73,13 +72,13 @@ def _fake_httpx_response(action_index: int = 0) -> MagicMock:
 
 
 # ===========================================================================
-# Criterion: Azure credentials load from a git-ignored .env;
+# Criterion: Ollama credentials load from a git-ignored .env;
 #            .env.example is committed
 # ===========================================================================
 
 
-class TestAzureCredentialFiles:
-    """Azure credential file-presence tests."""
+class TestOllamaCredentialFiles:
+    """Ollama credential file-presence tests."""
 
     @pytest.fixture(scope="class")
     def env_example_text(self) -> str:
@@ -87,20 +86,15 @@ class TestAzureCredentialFiles:
         assert path.exists(), ".env.example must exist at project root"
         return path.read_text()
 
-    def test_when_env_example_checked_then_azure_base_url_key_is_present(
+    def test_when_env_example_checked_then_ollama_base_url_key_is_present(
         self, env_example_text: str
     ) -> None:
-        assert "AZURE_OPENAI_BASE_URL" in env_example_text
+        assert "OLLAMA_BASE_URL" in env_example_text
 
-    def test_when_env_example_checked_then_azure_api_key_is_present(
+    def test_when_env_example_checked_then_ollama_api_key_is_present(
         self, env_example_text: str
     ) -> None:
-        assert "AZURE_OPENAI_API_KEY" in env_example_text
-
-    def test_when_env_example_checked_then_azure_api_version_is_present(
-        self, env_example_text: str
-    ) -> None:
-        assert "AZURE_OPENAI_API_VERSION" in env_example_text
+        assert "OLLAMA_API_KEY" in env_example_text
 
     def test_when_gitignore_checked_then_dot_env_is_excluded(self) -> None:
         gitignore = PROJECT_ROOT / ".gitignore"
@@ -122,12 +116,12 @@ class TestAzureCredentialFiles:
 
 
 def _patch_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for k, v in _AZURE_ENV.items():
+    for k, v in _OLLAMA_ENV.items():
         monkeypatch.setenv(k, v)
 
 
-class TestAzureApiContractStrict:
-    """Azure API request-structure tests.
+class TestOllamaApiContractStrict:
+    """Ollama API request-structure tests.
 
     Intercepts httpx.post and asserts on the request URL and body.
     """
@@ -135,14 +129,14 @@ class TestAzureApiContractStrict:
     def test_when_action_requested_then_url_contains_chat_completions(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         captured: dict[str, Any] = {}
         _patch_env(monkeypatch)
 
         with patch("httpx.post", side_effect=lambda url, **kw: _capture_and_respond(url, captured)):
-            call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.5
+            call_ollama_for_action_index(
+                _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
         assert "/chat/completions" in captured.get("url", ""), (
@@ -152,7 +146,7 @@ class TestAzureApiContractStrict:
     def test_when_action_requested_then_response_format_type_is_json_schema(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         captured: dict[str, Any] = {}
         _patch_env(monkeypatch)
@@ -161,8 +155,8 @@ class TestAzureApiContractStrict:
             "httpx.post",
             side_effect=lambda url, **kw: _capture_body_and_respond(kw, captured),
         ):
-            call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.5
+            call_ollama_for_action_index(
+                _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
         rf = captured.get("body", {}).get("response_format", {})
@@ -173,7 +167,7 @@ class TestAzureApiContractStrict:
     def test_when_action_requested_then_json_schema_strict_is_true(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         captured: dict[str, Any] = {}
         _patch_env(monkeypatch)
@@ -182,8 +176,8 @@ class TestAzureApiContractStrict:
             "httpx.post",
             side_effect=lambda url, **kw: _capture_body_and_respond(kw, captured),
         ):
-            call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.5
+            call_ollama_for_action_index(
+                _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
         rf = captured.get("body", {}).get("response_format", {})
@@ -192,10 +186,10 @@ class TestAzureApiContractStrict:
             f"response_format.json_schema.strict must be True; got {schema_block!r}"
         )
 
-    def test_when_action_requested_then_api_key_header_is_present(
+    def test_when_action_requested_then_authorization_bearer_header_is_present(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         captured: dict[str, Any] = {}
         _patch_env(monkeypatch)
@@ -204,19 +198,22 @@ class TestAzureApiContractStrict:
             "httpx.post",
             side_effect=lambda url, **kw: _capture_headers_and_respond(kw, captured),
         ):
-            call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.5
+            call_ollama_for_action_index(
+                _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
         headers_lower = {k.lower(): v for k, v in captured.get("headers", {}).items()}
-        assert "api-key" in headers_lower, (
-            f"Request must include 'api-key' header; got {list(headers_lower)}"
+        assert "authorization" in headers_lower, (
+            f"Request must include 'Authorization' header; got {list(headers_lower)}"
+        )
+        assert headers_lower["authorization"].startswith("Bearer "), (
+            f"Authorization header must use Bearer scheme; got {headers_lower['authorization']!r}"
         )
 
     def test_when_action_requested_then_temperature_is_injected_in_body(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         captured: dict[str, Any] = {}
         _patch_env(monkeypatch)
@@ -225,8 +222,8 @@ class TestAzureApiContractStrict:
             "httpx.post",
             side_effect=lambda url, **kw: _capture_body_and_respond(kw, captured),
         ):
-            call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.3
+            call_ollama_for_action_index(
+                _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.3
             )
 
         assert captured.get("body", {}).get("temperature") == pytest.approx(0.3), (
@@ -236,7 +233,7 @@ class TestAzureApiContractStrict:
     def test_when_action_requested_then_top_p_is_injected_in_body(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         captured: dict[str, Any] = {}
         _patch_env(monkeypatch)
@@ -245,8 +242,12 @@ class TestAzureApiContractStrict:
             "httpx.post",
             side_effect=lambda url, **kw: _capture_body_and_respond(kw, captured),
         ):
-            call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.5, top_p=0.85
+            call_ollama_for_action_index(
+                _make_obs(),
+                _make_legal_actions(),
+                model="gpt-oss:120b",
+                temperature=0.5,
+                top_p=0.85,
             )
 
         assert captured.get("body", {}).get("top_p") == pytest.approx(0.85), (
@@ -280,14 +281,14 @@ class TestLlmOutputIsLegalIndex:
     def test_when_model_returns_index_0_then_function_returns_0(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         legal = _make_legal_actions()
         _patch_env(monkeypatch)
 
         with patch("httpx.post", return_value=_fake_httpx_response(0)):
-            result = call_azure_for_action_index(
-                _make_obs(), legal, model="gpt-4.1", temperature=0.5
+            result = call_ollama_for_action_index(
+                _make_obs(), legal, model="gpt-oss:120b", temperature=0.5
             )
 
         assert result == 0
@@ -295,15 +296,15 @@ class TestLlmOutputIsLegalIndex:
     def test_when_model_returns_last_valid_index_then_function_returns_that_index(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         legal = _make_legal_actions()
         last = len(legal) - 1
         _patch_env(monkeypatch)
 
         with patch("httpx.post", return_value=_fake_httpx_response(last)):
-            result = call_azure_for_action_index(
-                _make_obs(), legal, model="gpt-4.1", temperature=0.5
+            result = call_ollama_for_action_index(
+                _make_obs(), legal, model="gpt-oss:120b", temperature=0.5
             )
 
         assert result == last
@@ -311,14 +312,14 @@ class TestLlmOutputIsLegalIndex:
     def test_when_model_returns_index_then_index_is_within_bounds(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         legal = _make_legal_actions()
         _patch_env(monkeypatch)
 
         with patch("httpx.post", return_value=_fake_httpx_response(1)):
-            result = call_azure_for_action_index(
-                _make_obs(), legal, model="gpt-4.1", temperature=0.5
+            result = call_ollama_for_action_index(
+                _make_obs(), legal, model="gpt-oss:120b", temperature=0.5
             )
 
         assert result is not None
@@ -330,7 +331,7 @@ class TestLlmOutputIsLegalIndex:
         self, idx: int
     ) -> None:
         """Property: for any valid index, the function returns exactly that integer."""
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         legal = [
             {"action_type": 2, "param_a": i, "param_b": 0, "param_c": 1, "param_d": 0}
@@ -338,11 +339,11 @@ class TestLlmOutputIsLegalIndex:
         ]
 
         with (
-            patch.dict(os.environ, _AZURE_ENV),
+            patch.dict(os.environ, _OLLAMA_ENV),
             patch("httpx.post", return_value=_fake_httpx_response(idx)),
         ):
-            result = call_azure_for_action_index(
-                _make_obs(), legal, model="gpt-4.1", temperature=0.5
+            result = call_ollama_for_action_index(
+                _make_obs(), legal, model="gpt-oss:120b", temperature=0.5
             )
 
         assert result == idx
@@ -385,32 +386,32 @@ class TestRenderActionPrompt:
         result = render_action_prompt(_make_obs(), _make_legal_actions(), strategy_hint=hint)
         assert hint in result, "strategy_hint must appear verbatim in the rendered prompt"
 
-    def test_when_azure_client_called_then_render_action_prompt_is_invoked(
+    def test_when_ollama_client_called_then_render_action_prompt_is_invoked(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """render_action_prompt must be the single source of truth for prompt construction."""
-        from src.agents import azure_openai
+        from src.agents import ollama_client
 
         call_count: list[int] = [0]
-        real_render = azure_openai.render_action_prompt
+        real_render = ollama_client.render_action_prompt
 
         def spy_render(*args: Any, **kwargs: Any) -> str:
             call_count[0] += 1
             return real_render(*args, **kwargs)
 
-        monkeypatch.setattr(azure_openai, "render_action_prompt", spy_render)
+        monkeypatch.setattr(ollama_client, "render_action_prompt", spy_render)
         _patch_env(monkeypatch)
 
         with patch("httpx.post", return_value=_fake_httpx_response(0)):
-            azure_openai.call_azure_for_action_index(
-                _make_obs(), _make_legal_actions(), model="gpt-4.1", temperature=0.5
+            ollama_client.call_ollama_for_action_index(
+                _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
         assert call_count[0] >= 1, (
             "render_action_prompt must be called at least once per LLM request"
         )
 
-    def test_when_source_files_scanned_then_no_azure_key_is_hardcoded(self) -> None:
+    def test_when_source_files_scanned_then_no_api_key_is_hardcoded(self) -> None:
         """The API key must never appear as a literal in source files."""
         src_dir = PROJECT_ROOT / "src"
         hex32 = re.compile(r'["\'][0-9a-fA-F]{32}["\']')

--- a/tests/test_ac61.py
+++ b/tests/test_ac61.py
@@ -1,10 +1,10 @@
 """
 Acceptance tests for issue #61:
-feat: wire Azure LLM opponents into CLI, agent loader, and self-play training
+feat: wire Ollama LLM opponents into CLI, agent loader, and self-play training
 
 Criteria the oracle marks NOT VERIFIABLE (non-blocking timeout, determinism,
 hyperparameter-YAML wiring, baseline win-rates, all-tests-pass, clean-code)
-are omitted.  Code-coverage ≥ 80% is a CI gate, not a unit assertion.
+are omitted.  Code-coverage >= 80% is a CI gate, not a unit assertion.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ _PROJECT_ROOT = pathlib.Path(__file__).parent.parent
 
 
 def _fake_httpx_response(action_index: int = 0) -> MagicMock:
-    """Return a mock that looks like an httpx.Response from Azure."""
+    """Return a mock that looks like an httpx.Response from Ollama."""
     content = json.dumps({"action_index": action_index})
     body = {"choices": [{"message": {"content": content}}]}
     resp = MagicMock()
@@ -69,7 +69,7 @@ def _minimal_legal() -> list[dict]:
 def _write_player_profiles(path: pathlib.Path, n: int) -> None:
     """Write N player profiles as a flat YAML list.
 
-    player_id runs 0..n-1 so all ids stay in the valid 0–5 range for n ≤ 6.
+    player_id runs 0..n-1 so all ids stay in the valid 0-5 range for n <= 6.
     """
     profiles = [
         {
@@ -77,7 +77,7 @@ def _write_player_profiles(path: pathlib.Path, n: int) -> None:
             "temperature": round(0.1 + 0.1 * i, 1),
             "top_p": 0.9,
             "strategy_hint": f"Profile {i}: play optimally.",
-            "model": "gpt-4.1",
+            "model": "gpt-oss:120b",
         }
         for i in range(n)
     ]
@@ -85,22 +85,18 @@ def _write_player_profiles(path: pathlib.Path, n: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# [T2] LLM opponent calls Azure OpenAI via /chat/completions
+# [T2] LLM opponent calls Ollama via /chat/completions
 #      with json_schema strict output
 # ---------------------------------------------------------------------------
 
 
-class TestAzureApiContract:
-    """The Azure client must POST to /chat/completions with json_schema strict."""
+class TestOllamaApiContract:
+    """The Ollama client must POST to /chat/completions with json_schema strict."""
 
     def _call_with_capture(self, monkeypatch) -> dict:
-        """Call call_azure_for_action_index; return the captured httpx.post kwargs."""
-        monkeypatch.setenv(
-            "AZURE_OPENAI_BASE_URL",
-            "https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-        )
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-key-for-test")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview")
+        """Call call_ollama_for_action_index; return the captured httpx.post kwargs."""
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
 
         captured: dict = {}
 
@@ -109,16 +105,16 @@ class TestAzureApiContract:
             captured["kwargs"] = kwargs
             return _fake_httpx_response(0)
 
-        from src.agents.azure_openai import call_azure_for_action_index
+        from src.agents.ollama_client import call_ollama_for_action_index
 
         with (
             patch("httpx.post", side_effect=fake_post),
-            patch("src.agents.azure_openai.render_action_prompt", return_value="test prompt"),
+            patch("src.agents.ollama_client.render_action_prompt", return_value="test prompt"),
         ):
-            call_azure_for_action_index(
+            call_ollama_for_action_index(
                 _minimal_obs(),
                 _minimal_legal(),
-                model="gpt-4.1",
+                model="gpt-oss:120b",
             )
         return captured
 
@@ -158,46 +154,46 @@ class TestAzureApiContract:
             f"Schema must declare 'action_index'; got {schema!r}"
         )
 
-    def test_when_action_requested_then_api_key_header_is_set(self, monkeypatch) -> None:
-        """Request must use 'api-key' header (Azure convention, not Bearer)."""
+    def test_when_action_requested_then_authorization_bearer_header_is_set(
+        self, monkeypatch
+    ) -> None:
+        """Request must use 'Authorization: Bearer <key>' header (Ollama convention)."""
         captured = self._call_with_capture(monkeypatch)
         headers = captured["kwargs"].get("headers", {})
-        lower_keys = {k.lower() for k in headers}
-        assert "api-key" in lower_keys, f"'api-key' header must be present; got {list(headers)!r}"
+        lower_keys = {k.lower(): v for k, v in headers.items()}
+        assert "authorization" in lower_keys, (
+            f"'Authorization' header must be present; got {list(headers)!r}"
+        )
+        assert lower_keys["authorization"].startswith("Bearer "), (
+            f"Authorization must use Bearer scheme; got {lower_keys['authorization']!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# [UNIT] Azure credentials load from .env; .env.example is committed
+# [UNIT] Ollama credentials load from .env; .env.example is committed
 # ---------------------------------------------------------------------------
 
 
-class TestAzureCredentials:
+class TestOllamaCredentials:
     def test_when_env_example_checked_then_file_exists_at_project_root(self) -> None:
         """.env.example must exist at the project root (committed to git)."""
         assert (_PROJECT_ROOT / ".env.example").exists(), (
             ".env.example must be present and committed"
         )
 
-    def test_when_env_example_read_then_azure_base_url_placeholder_is_present(
+    def test_when_env_example_read_then_ollama_base_url_placeholder_is_present(
         self,
     ) -> None:
-        """.env.example must contain AZURE_OPENAI_BASE_URL."""
+        """.env.example must contain OLLAMA_BASE_URL."""
         content = (_PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_BASE_URL" in content
+        assert "OLLAMA_BASE_URL" in content
 
-    def test_when_env_example_read_then_azure_api_key_placeholder_is_present(
+    def test_when_env_example_read_then_ollama_api_key_placeholder_is_present(
         self,
     ) -> None:
-        """.env.example must contain AZURE_OPENAI_API_KEY."""
+        """.env.example must contain OLLAMA_API_KEY."""
         content = (_PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_API_KEY" in content
-
-    def test_when_env_example_read_then_azure_api_version_placeholder_is_present(
-        self,
-    ) -> None:
-        """.env.example must contain AZURE_OPENAI_API_VERSION."""
-        content = (_PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_API_VERSION" in content
+        assert "OLLAMA_API_KEY" in content
 
     def test_when_gitignore_checked_then_dotenv_file_is_ignored(self) -> None:
         """.env must appear in .gitignore so credentials are never committed."""
@@ -208,13 +204,56 @@ class TestAzureCredentials:
 
     def test_when_ensure_env_loaded_called_twice_then_no_error_is_raised(self, monkeypatch) -> None:
         """ensure_env_loaded() must be idempotent — calling it twice must not raise."""
-        monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://fake")
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-key")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2025-01")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
         from src.utils.env import ensure_env_loaded
 
         ensure_env_loaded()
         ensure_env_loaded()  # must not raise
+
+    def test_when_no_creds_in_env_then_client_defaults_to_localhost(self) -> None:
+        """Without env vars the client must fall back to localhost, not raise."""
+        import os
+
+        from src.agents.ollama_client import DEFAULT_API_KEY, DEFAULT_BASE_URL
+
+        assert DEFAULT_BASE_URL.startswith("http://localhost"), (
+            f"DEFAULT_BASE_URL must point at localhost; got {DEFAULT_BASE_URL!r}"
+        )
+        assert DEFAULT_API_KEY == "ollama", (
+            f"DEFAULT_API_KEY must be 'ollama'; got {DEFAULT_API_KEY!r}"
+        )
+
+        # Verify the client builds the correct URL/key when env is absent
+
+        captured: dict = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {
+                "choices": [{"message": {"content": json.dumps({"action_index": 0})}}]
+            }
+            resp.raise_for_status = MagicMock(return_value=None)
+            return resp
+
+        excluded = {"OLLAMA_BASE_URL", "OLLAMA_API_KEY"}
+        clean_env = {k: v for k, v in os.environ.items() if k not in excluded}
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch("httpx.post", side_effect=fake_post),
+        ):
+            from src.agents.ollama_client import call_ollama_for_action_index
+
+            call_ollama_for_action_index(_minimal_obs(), _minimal_legal(), model="gpt-oss:120b")
+
+        assert "localhost" in captured.get("url", ""), (
+            f"URL must contain localhost when no env var set; got {captured.get('url')!r}"
+        )
+        auth = captured.get("headers", {}).get("Authorization", "")
+        assert "Bearer" in auth, f"Authorization must use Bearer scheme; got {auth!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +360,8 @@ class TestRenderActionPrompt:
         self, monkeypatch
     ) -> None:
         """The rendered prompt must never contain the raw API key value."""
-        secret = "super-secret-azure-key-xyz-98765"
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", secret)
+        secret = "super-secret-ollama-key-xyz-98765"
+        monkeypatch.setenv("OLLAMA_API_KEY", secret)
         from src.agents.action_prompt import render_action_prompt
 
         result = render_action_prompt(_minimal_obs(), _minimal_legal())
@@ -668,14 +707,14 @@ class TestBuildLlmOpponents:
                         "temperature": 0.1,
                         "top_p": 0.9,
                         "strategy_hint": "greedy",
-                        "model": "gpt-4.1",
+                        "model": "gpt-oss:120b",
                     },
                     {
                         "player_id": 1,
                         "temperature": 0.9,
                         "top_p": 0.8,
                         "strategy_hint": "random",
-                        "model": "gpt-4.1",
+                        "model": "gpt-oss:120b",
                     },
                 ]
             )
@@ -705,24 +744,12 @@ class TestBuildLlmOpponents:
 
 
 # ---------------------------------------------------------------------------
-# [UNIT] No Ollama/BAML references in risiko_rl/, training/, config/
+# [UNIT] No BAML references in risiko_rl/, training/, config/
+#        (Ollama references are expected in src/ — not scanned here)
 # ---------------------------------------------------------------------------
 
 
-class TestNoOllamaBamlReferences:
-    @pytest.mark.parametrize("directory", ["risiko_rl", "training", "config"])
-    def test_when_directory_scanned_then_no_ollama_references_found(self, directory: str) -> None:
-        """No file under the directory may reference Ollama."""
-        target = _PROJECT_ROOT / directory
-        if not target.exists():
-            pytest.skip(f"{directory}/ does not exist yet")
-        result = subprocess.run(
-            ["grep", "-ri", "ollama", str(target)],
-            capture_output=True,
-            text=True,
-        )
-        assert result.stdout == "", f"Ollama reference(s) found in {directory}/:\n{result.stdout}"
-
+class TestNoBamlReferences:
     @pytest.mark.parametrize("directory", ["risiko_rl", "training", "config"])
     def test_when_directory_scanned_then_no_baml_references_found(self, directory: str) -> None:
         """No file under the directory may reference BAML."""

--- a/tests/test_ac62.py
+++ b/tests/test_ac62.py
@@ -15,13 +15,13 @@ Criteria covered (oracle-verified as UNIT or T2):
   [UNIT] SelfPlayTrainer.train() smoke run writes a .pt checkpoint to a tmp dir and
          load_checkpoint round-trips episode counter, RNG state, and opponent
   [UNIT] With llm_profiles_path set, the trainer builds N-1 LLMOpponents
-         (Azure call mocked, no network)
+         (Ollama call mocked, no network)
   [UNIT] No magic numbers — all knobs pulled from TrainingConfig/RewardConfig
   [UNIT] Results saved as CSV + TensorBoard logs under results/; every run tagged
          with its seed and config file path
 
 Criteria already covered by test_ac60.py / test_ac61.py (omitted here to avoid
-duplication): Azure /chat/completions contract, LLM output is index, render_action_prompt,
+duplication): Ollama /chat/completions contract, LLM output is index, render_action_prompt,
 .env.example credential files, basic checkpoint save/load.
 """
 
@@ -71,7 +71,7 @@ def _skip_action() -> dict:
     return {"action_type": 5, "param_a": 0, "param_b": 0, "param_c": 0, "param_d": 0}
 
 
-def _fake_azure_response(action_index: int = 0) -> MagicMock:
+def _fake_ollama_response(action_index: int = 0) -> MagicMock:
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {
@@ -88,7 +88,7 @@ def _write_player_profiles(path: pathlib.Path, n: int) -> None:
             "temperature": round(0.1 + 0.1 * i, 1),
             "top_p": 0.9,
             "strategy_hint": f"Profile {i}: play optimally.",
-            "model": "gpt-4.1",
+            "model": "gpt-oss:120b",
         }
         for i in range(n)
     ]
@@ -511,7 +511,7 @@ class TestCheckpointRoundTripEpisodeRng:
 
 # ===========================================================================
 # [UNIT]  With llm_profiles_path set, the trainer builds N-1 LLMOpponents
-#         (Azure call mocked, no network)
+#         (Ollama call mocked, no network)
 # ===========================================================================
 
 
@@ -529,12 +529,8 @@ class TestSelfPlayTrainerLlmProfiles:
         profiles_yaml = tmp_path / "profiles.yaml"
         _write_player_profiles(profiles_yaml, 3)
 
-        monkeypatch.setenv(
-            "AZURE_OPENAI_BASE_URL",
-            "https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-        )
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
 
         cfg = TrainingConfig(
             seed=0,
@@ -544,7 +540,7 @@ class TestSelfPlayTrainerLlmProfiles:
             ),
         )
 
-        with patch("httpx.post", return_value=_fake_azure_response(0)):
+        with patch("httpx.post", return_value=_fake_ollama_response(0)):
             trainer = SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, max_turns=10)
 
         assert trainer._llm_opponents is not None
@@ -556,19 +552,15 @@ class TestSelfPlayTrainerLlmProfiles:
     def test_when_profiles_path_set_then_no_real_http_call_is_made_on_construction(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Constructing LLMOpponents must not trigger any real Azure HTTP call."""
+        """Constructing LLMOpponents must not trigger any real Ollama HTTP call."""
         from src.config import SelfPlayConfig, TrainingConfig
         from training.self_play import SelfPlayTrainer
 
         profiles_yaml = tmp_path / "profiles3.yaml"
         _write_player_profiles(profiles_yaml, 2)
 
-        monkeypatch.setenv(
-            "AZURE_OPENAI_BASE_URL",
-            "https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-        )
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
 
         cfg = TrainingConfig(
             seed=0,
@@ -582,13 +574,14 @@ class TestSelfPlayTrainerLlmProfiles:
 
         def counting_post(*args: Any, **kwargs: Any) -> MagicMock:
             call_count[0] += 1
-            return _fake_azure_response(0)
+            return _fake_ollama_response(0)
 
         with patch("httpx.post", side_effect=counting_post):
             SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, max_turns=10)
 
         assert call_count[0] == 0, (
-            f"No Azure HTTP calls expected during SelfPlayTrainer construction; got {call_count[0]}"
+            "No Ollama HTTP calls expected during SelfPlayTrainer construction;"
+            f" got {call_count[0]}"
         )
 
 

--- a/tests/test_action_prompt.py
+++ b/tests/test_action_prompt.py
@@ -378,11 +378,11 @@ class TestStatusLine:
 class TestSecretsHygiene:
     """Confirm no credential material appears in the rendered prompt."""
 
-    def test_when_prompt_rendered_then_azure_api_key_var_absent(self, obs):
-        assert "AZURE_OPENAI_API_KEY" not in render_action_prompt(obs, [_skip()])
+    def test_when_prompt_rendered_then_ollama_api_key_var_absent(self, obs):
+        assert "OLLAMA_API_KEY" not in render_action_prompt(obs, [_skip()])
 
-    def test_when_prompt_rendered_then_azure_base_url_var_absent(self, obs):
-        assert "AZURE_OPENAI_BASE_URL" not in render_action_prompt(obs, [_skip()])
+    def test_when_prompt_rendered_then_ollama_base_url_var_absent(self, obs):
+        assert "OLLAMA_BASE_URL" not in render_action_prompt(obs, [_skip()])
 
     def test_when_prompt_rendered_then_no_32_char_hex_key_pattern(self, obs):
         prompt = render_action_prompt(obs, [_skip()])

--- a/tests/test_board_global.py
+++ b/tests/test_board_global.py
@@ -1,9 +1,9 @@
 """Tests for global acceptance criteria (Issue #48, oracle tier UNIT / T2).
 
 Covered:
-  [T2]   LLM opponent calls Azure OpenAI via /chat/completions with
+  [T2]   LLM opponent calls Ollama via /chat/completions with
           json_schema strict output.
-  [UNIT] Azure credentials in .env; .env.example is committed.
+  [UNIT] Ollama credentials in .env; .env.example is committed.
   [UNIT] LLM output is an index into legal_actions — always legal.
   [UNIT] render_action_prompt() is the single source of truth for the prompt.
 """
@@ -18,7 +18,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from src.agents.action_prompt import render_action_prompt
-from src.agents.azure_openai import call_azure_for_action_index
+from src.agents.ollama_client import call_ollama_for_action_index
 from src.utils.constants import NUM_TERRITORIES
 
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -52,7 +52,7 @@ def _skip() -> dict[str, int]:
     return {"action_type": 5, "param_a": 0, "param_b": 0, "param_c": 0, "param_d": 0}
 
 
-def _make_azure_response(action_index: int) -> MagicMock:
+def _make_ollama_response(action_index: int) -> MagicMock:
     resp = MagicMock()
     resp.raise_for_status = MagicMock()
     resp.json.return_value = {
@@ -61,22 +61,21 @@ def _make_azure_response(action_index: int) -> MagicMock:
     return resp
 
 
-def _call_azure(legal_actions, *, temperature=0.5, top_p=0.9, model="gpt-4.1"):
-    """Call call_azure_for_action_index with env vars stubbed out."""
-    return call_azure_for_action_index(
+def _call_ollama(legal_actions, *, temperature=0.5, top_p=0.9, model="gpt-oss:120b"):
+    """Call call_ollama_for_action_index with env vars stubbed out."""
+    return call_ollama_for_action_index(
         obs=_make_obs(),
         legal_actions=legal_actions,
         model=model,
-        base_url="https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-        api_key="fake-key",
-        api_version="2024-12-01-preview",
+        base_url="http://localhost:11434/v1",
+        api_key="ollama",
         temperature=temperature,
         top_p=top_p,
     )
 
 
 # ---------------------------------------------------------------------------
-# .env.example committed with all three required keys
+# .env.example committed with required keys
 # ---------------------------------------------------------------------------
 
 
@@ -86,19 +85,14 @@ def test_when_env_example_checked_then_file_exists_at_project_root():
     )
 
 
-def test_when_env_example_read_then_azure_openai_base_url_key_is_present():
+def test_when_env_example_read_then_ollama_base_url_key_is_present():
     content = (PROJECT_ROOT / ".env.example").read_text()
-    assert "AZURE_OPENAI_BASE_URL" in content
+    assert "OLLAMA_BASE_URL" in content
 
 
-def test_when_env_example_read_then_azure_openai_api_key_is_present():
+def test_when_env_example_read_then_ollama_api_key_is_present():
     content = (PROJECT_ROOT / ".env.example").read_text()
-    assert "AZURE_OPENAI_API_KEY" in content
-
-
-def test_when_env_example_read_then_azure_openai_api_version_is_present():
-    content = (PROJECT_ROOT / ".env.example").read_text()
-    assert "AZURE_OPENAI_API_VERSION" in content
+    assert "OLLAMA_API_KEY" in content
 
 
 # ---------------------------------------------------------------------------
@@ -153,81 +147,81 @@ def test_when_render_action_prompt_called_with_any_n_actions_then_no_error_is_ra
 
 
 # ---------------------------------------------------------------------------
-# Azure OpenAI /chat/completions with json_schema strict
+# Ollama /chat/completions with json_schema strict
 # ---------------------------------------------------------------------------
 
 
-def test_when_azure_called_then_url_contains_chat_completions():
-    """Criterion: LLM opponent calls Azure OpenAI via /chat/completions."""
+def test_when_ollama_called_then_url_contains_chat_completions():
+    """Criterion: LLM opponent calls Ollama via /chat/completions."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
         captured["url"] = url
-        return _make_azure_response(0)
+        return _make_ollama_response(0)
 
     with patch("httpx.post", side_effect=_fake_post):
-        _call_azure([_skip()])
+        _call_ollama([_skip()])
 
     assert "/chat/completions" in captured.get("url", ""), (
         "Request URL must include /chat/completions"
     )
 
 
-def test_when_azure_called_then_response_format_type_is_json_schema():
+def test_when_ollama_called_then_response_format_type_is_json_schema():
     """Criterion: request uses json_schema response_format."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
         captured["body"] = kwargs.get("json", {})
-        return _make_azure_response(0)
+        return _make_ollama_response(0)
 
     with patch("httpx.post", side_effect=_fake_post):
-        _call_azure([_skip()])
+        _call_ollama([_skip()])
 
     body = captured.get("body", {})
     assert "response_format" in body
     assert body["response_format"].get("type") == "json_schema"
 
 
-def test_when_azure_called_then_json_schema_strict_is_true():
+def test_when_ollama_called_then_json_schema_strict_is_true():
     """Criterion: json_schema strict output enforced."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
         captured["body"] = kwargs.get("json", {})
-        return _make_azure_response(0)
+        return _make_ollama_response(0)
 
     with patch("httpx.post", side_effect=_fake_post):
-        _call_azure([_skip()])
+        _call_ollama([_skip()])
 
     schema_block = captured["body"].get("response_format", {}).get("json_schema", {})
     assert schema_block.get("strict") is True
 
 
-def test_when_azure_called_then_temperature_is_in_request_body():
-    """Criterion: per-call temperature injected into the Azure request body."""
+def test_when_ollama_called_then_temperature_is_in_request_body():
+    """Criterion: per-call temperature injected into the Ollama request body."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
         captured["body"] = kwargs.get("json", {})
-        return _make_azure_response(0)
+        return _make_ollama_response(0)
 
     with patch("httpx.post", side_effect=_fake_post):
-        _call_azure([_skip()], temperature=0.3)
+        _call_ollama([_skip()], temperature=0.3)
 
     assert captured["body"].get("temperature") == pytest.approx(0.3)
 
 
-def test_when_azure_called_then_top_p_is_in_request_body():
-    """Criterion: per-call top_p injected into the Azure request body."""
+def test_when_ollama_called_then_top_p_is_in_request_body():
+    """Criterion: per-call top_p injected into the Ollama request body."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
         captured["body"] = kwargs.get("json", {})
-        return _make_azure_response(0)
+        return _make_ollama_response(0)
 
     with patch("httpx.post", side_effect=_fake_post):
-        _call_azure([_skip()], top_p=0.95)
+        _call_ollama([_skip()], top_p=0.95)
 
     assert captured["body"].get("top_p") == pytest.approx(0.95)
 
@@ -237,17 +231,17 @@ def test_when_azure_called_then_top_p_is_in_request_body():
 # ---------------------------------------------------------------------------
 
 
-def test_when_azure_returns_action_index_then_returned_value_is_int():
-    with patch("httpx.post", return_value=_make_azure_response(0)):
-        result = _call_azure([_skip(), _reinforce(0, 1)])
+def test_when_ollama_returns_action_index_then_returned_value_is_int():
+    with patch("httpx.post", return_value=_make_ollama_response(0)):
+        result = _call_ollama([_skip(), _reinforce(0, 1)])
     assert isinstance(result, int)
 
 
-def test_when_azure_returns_action_index_then_returned_value_is_within_legal_bounds():
+def test_when_ollama_returns_action_index_then_returned_value_is_within_legal_bounds():
     """Criterion: the chosen action is always legal by construction."""
     legal_actions = [_skip(), _reinforce(0, 1), _reinforce(1, 2)]
-    with patch("httpx.post", return_value=_make_azure_response(2)):
-        index = _call_azure(legal_actions)
+    with patch("httpx.post", return_value=_make_ollama_response(2)):
+        index = _call_ollama(legal_actions)
     assert 0 <= index < len(legal_actions)
 
 
@@ -256,9 +250,9 @@ def test_when_azure_returns_action_index_then_returned_value_is_within_legal_bou
     n_actions=st.integers(min_value=10, max_value=20),
 )
 @settings(max_examples=30)
-def test_when_azure_returns_any_valid_index_then_it_is_always_in_range(chosen, n_actions):
+def test_when_ollama_returns_any_valid_index_then_it_is_always_in_range(chosen, n_actions):
     """Property: any valid index the LLM returns must be in [0, len(legal_actions))."""
     legal_actions = [_skip()] * n_actions
-    with patch("httpx.post", return_value=_make_azure_response(chosen)):
-        index = _call_azure(legal_actions)
+    with patch("httpx.post", return_value=_make_ollama_response(chosen)):
+        index = _call_ollama(legal_actions)
     assert 0 <= index < len(legal_actions)

--- a/tests/test_env_secrets.py
+++ b/tests/test_env_secrets.py
@@ -1,7 +1,7 @@
 """Source-blind tests for .env.example, git-ignore, and render_action_prompt() — Issue #56.
 
 Criteria covered:
-- .env.example keys exactly match AZURE_OPENAI_BASE_URL / _API_KEY / _API_VERSION
+- .env.example keys exactly match OLLAMA_BASE_URL / OLLAMA_API_KEY
 - git check-ignore .env confirms .env is ignored
 - render_action_prompt() returns a non-empty string, embeds legal action indices,
   prepends strategy_hint before the actions list, and never leaks the API key.
@@ -25,9 +25,8 @@ _REPO_ROOT = Path(__file__).parent.parent  # tests/ → repo root
 _ENV_EXAMPLE = _REPO_ROOT / ".env.example"
 
 _REQUIRED_KEYS = {
-    "AZURE_OPENAI_BASE_URL",
-    "AZURE_OPENAI_API_KEY",
-    "AZURE_OPENAI_API_VERSION",
+    "OLLAMA_BASE_URL",
+    "OLLAMA_API_KEY",
 }
 
 
@@ -48,23 +47,18 @@ def env_example_keys(env_example_lines) -> set[str]:
     return {line.split("=", 1)[0].strip() for line in env_example_lines if "=" in line}
 
 
-def test_env_example_contains_azure_openai_base_url(env_example_keys):
-    """Criterion: .env.example must declare AZURE_OPENAI_BASE_URL."""
-    assert "AZURE_OPENAI_BASE_URL" in env_example_keys
+def test_env_example_contains_ollama_base_url(env_example_keys):
+    """Criterion: .env.example must declare OLLAMA_BASE_URL."""
+    assert "OLLAMA_BASE_URL" in env_example_keys
 
 
-def test_env_example_contains_azure_openai_api_key(env_example_keys):
-    """Criterion: .env.example must declare AZURE_OPENAI_API_KEY."""
-    assert "AZURE_OPENAI_API_KEY" in env_example_keys
-
-
-def test_env_example_contains_azure_openai_api_version(env_example_keys):
-    """Criterion: .env.example must declare AZURE_OPENAI_API_VERSION."""
-    assert "AZURE_OPENAI_API_VERSION" in env_example_keys
+def test_env_example_contains_ollama_api_key(env_example_keys):
+    """Criterion: .env.example must declare OLLAMA_API_KEY."""
+    assert "OLLAMA_API_KEY" in env_example_keys
 
 
 def test_env_example_keys_exactly_match_required_set(env_example_keys):
-    """Criterion: .env.example keys exactly match the three required env vars.
+    """Criterion: .env.example keys exactly match the two required env vars.
 
     No extra undeclared keys and no missing keys.
     """
@@ -173,16 +167,16 @@ def test_when_strategy_hint_provided_then_it_appears_before_legal_actions_sectio
     )
 
 
-def test_when_render_action_prompt_is_called_then_azure_api_key_literal_is_absent():
-    """The prompt output must never contain a hardcoded Azure API key value.
+def test_when_render_action_prompt_is_called_then_ollama_api_key_literal_is_absent():
+    """The prompt output must never contain a hardcoded Ollama API key value.
 
     Criterion: the API key is never hardcoded in source.
     """
     from src.agents.action_prompt import render_action_prompt
 
     known_key_patterns = [
-        "AZURE_OPENAI_API_KEY=",
-        "api-key:",
+        "OLLAMA_API_KEY=",
+        "Authorization:",
     ]
     result = render_action_prompt(_FAKE_OBS, _FAKE_LEGAL)
     for pattern in known_key_patterns:

--- a/tests/test_global_criteria_r4.py
+++ b/tests/test_global_criteria_r4.py
@@ -1,7 +1,7 @@
 """Example tests for verifiable global acceptance criteria — Issue #49.
 
 Covers:
-  - .env.example is committed with the three required variable names
+  - .env.example is committed with the two required Ollama variable names
   - LLM output is an index into legal_actions (action always legal)
   - render_action_prompt() is the single source of truth for the LLM prompt
 
@@ -49,27 +49,23 @@ def _skip_action() -> dict:
 
 
 # ── .env.example committed with required credentials ─────────────────────────
-# Criterion: Azure credentials load from a git-ignored .env
-#            (AZURE_OPENAI_BASE_URL / _API_KEY / _API_VERSION); .env.example is committed.
+# Criterion: Ollama credentials load from a git-ignored .env
+#            (OLLAMA_BASE_URL / OLLAMA_API_KEY); .env.example is committed.
 
 
 class TestEnvExample:
-    """Criterion: .env.example committed with all three Azure credential variable names."""
+    """Criterion: .env.example committed with both Ollama credential variable names."""
 
     def test_when_env_example_checked_file_exists_at_project_root(self):
         assert (PROJECT_ROOT / ".env.example").is_file()
 
-    def test_when_env_example_read_azure_openai_base_url_variable_is_present(self):
+    def test_when_env_example_read_ollama_base_url_variable_is_present(self):
         content = (PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_BASE_URL" in content
+        assert "OLLAMA_BASE_URL" in content
 
-    def test_when_env_example_read_azure_openai_api_key_variable_is_present(self):
+    def test_when_env_example_read_ollama_api_key_variable_is_present(self):
         content = (PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_API_KEY" in content
-
-    def test_when_env_example_read_azure_openai_api_version_variable_is_present(self):
-        content = (PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_API_VERSION" in content
+        assert "OLLAMA_API_KEY" in content
 
     def test_when_gitignore_present_dotenv_file_is_excluded_from_version_control(self):
         gitignore = PROJECT_ROOT / ".gitignore"
@@ -83,7 +79,7 @@ class TestEnvExample:
 # Criterion: LLM output is an index into legal_actions — the chosen action is
 #            always legal by construction.
 #
-# call_azure_for_action_index(obs, legal_actions, *, model, base_url, api_key, ...)
+# call_ollama_for_action_index(obs, legal_actions, *, model, base_url, api_key, ...)
 #   → int | None   (the index, not the action element)
 
 
@@ -104,37 +100,37 @@ class TestLLMOutputIsIndex:
         obs = _minimal_obs()
         with (
             mock.patch("httpx.post", return_value=fake_resp),
-            mock.patch("src.agents.azure_openai.ensure_env_loaded"),
+            mock.patch("src.agents.ollama_client.ensure_env_loaded"),
         ):
-            from src.agents.azure_openai import call_azure_for_action_index
+            from src.agents.ollama_client import call_ollama_for_action_index
 
-            return call_azure_for_action_index(
+            return call_ollama_for_action_index(
                 obs=obs,
                 legal_actions=legal_actions,
-                model="gpt-4.1",
-                base_url="https://fake.openai.azure.com/",
-                api_key="fake-key",
+                model="gpt-oss:120b",
+                base_url="http://localhost:11434/v1",
+                api_key="ollama",
                 temperature=0.5,
                 top_p=0.9,
             )
 
-    def test_when_azure_returns_index_1_result_is_1(self):
+    def test_when_ollama_returns_index_1_result_is_1(self):
         legal_actions = [_skip_action(), _skip_action(), _skip_action()]
         result = self._call_with_mocked_http(action_index=1, legal_actions=legal_actions)
         assert result == 1
 
-    def test_when_azure_returns_index_0_result_is_0(self):
+    def test_when_ollama_returns_index_0_result_is_0(self):
         legal_actions = [_skip_action(), _skip_action(), _skip_action()]
         result = self._call_with_mocked_http(action_index=0, legal_actions=legal_actions)
         assert result == 0
 
-    def test_when_azure_returns_last_valid_index_result_is_in_range(self):
+    def test_when_ollama_returns_last_valid_index_result_is_in_range(self):
         legal_actions = [_skip_action()] * 4
         result = self._call_with_mocked_http(action_index=3, legal_actions=legal_actions)
         assert result == 3
         assert 0 <= result < len(legal_actions)
 
-    def test_when_azure_returns_out_of_range_index_result_is_none(self):
+    def test_when_ollama_returns_out_of_range_index_result_is_none(self):
         """Out-of-range action_index must be rejected (returns None)."""
         legal_actions = [_skip_action(), _skip_action()]
         result = self._call_with_mocked_http(action_index=99, legal_actions=legal_actions)

--- a/tests/test_llm_opponent.py
+++ b/tests/test_llm_opponent.py
@@ -1,4 +1,4 @@
-"""Tests for the LLM opponent with mocked Azure OpenAI client."""
+"""Tests for the LLM opponent with mocked Ollama client."""
 
 from __future__ import annotations
 
@@ -145,25 +145,23 @@ class TestConfiguration:
 
     def test_default_values(self) -> None:
         a = LLMOpponent()
-        assert a._model == "gpt-4.1"
+        assert a._model == "gpt-oss:120b"
         assert a._timeout == 30.0
         assert a._temperature == 0.1
 
     def test_custom_values(self) -> None:
-        a = LLMOpponent(model="gpt-4o", timeout=2.0, temperature=0.5)
-        assert a._model == "gpt-4o"
+        a = LLMOpponent(model="gpt-oss:20b", timeout=2.0, temperature=0.5)
+        assert a._model == "gpt-oss:20b"
         assert a._timeout == 2.0
         assert a._temperature == 0.5
 
-    def test_custom_azure_overrides(self) -> None:
+    def test_custom_ollama_overrides(self) -> None:
         a = LLMOpponent(
-            base_url="https://example.openai.azure.com/openai/deployments/gpt-4.1",
-            api_key="secret",
-            api_version="2024-12-01-preview",
+            base_url="http://localhost:11434/v1",
+            api_key="my-ollama-key",
         )
-        assert a._base_url == "https://example.openai.azure.com/openai/deployments/gpt-4.1"
-        assert a._api_key == "secret"
-        assert a._api_version == "2024-12-01-preview"
+        assert a._base_url == "http://localhost:11434/v1"
+        assert a._api_key == "my-ollama-key"
 
     def test_when_player_config_set_strategy_hint_is_stored(self) -> None:
         from src.agents.player_config import PlayerConfig
@@ -206,33 +204,31 @@ class TestConfiguration:
 
 
 # ------------------------------------------------------------------
-# Azure call wiring
+# Ollama call wiring
 # ------------------------------------------------------------------
 
 
-class TestAzureWiring:
-    """_call_with_timeout forwards config to the Azure client."""
+class TestOllamaWiring:
+    """_call_with_timeout forwards config to the Ollama client."""
 
-    def test_when_act_then_azure_client_receives_overrides(self, dummy_obs, dummy_legal) -> None:
+    def test_when_act_then_ollama_client_receives_overrides(self, dummy_obs, dummy_legal) -> None:
         from src.agents.player_config import PlayerConfig
 
         config = PlayerConfig(player_id=0, temperature=0.7, top_p=0.85, strategy_hint="hint")
         a = LLMOpponent(
             player_config=config,
-            base_url="https://example/deployments/gpt-4.1",
-            api_key="k",
-            api_version="2024-12-01-preview",
+            base_url="http://localhost:11434/v1",
+            api_key="test-key",
         )
         with patch(
-            "src.agents.llm_opponent.call_azure_for_action_index", return_value=0
+            "src.agents.llm_opponent.call_ollama_for_action_index", return_value=0
         ) as mock_call:
             a.act(dummy_obs, dummy_legal)
         mock_call.assert_called_once()
         kwargs = mock_call.call_args.kwargs
-        assert kwargs["model"] == "gpt-4.1"
-        assert kwargs["base_url"] == "https://example/deployments/gpt-4.1"
-        assert kwargs["api_key"] == "k"
-        assert kwargs["api_version"] == "2024-12-01-preview"
+        assert kwargs["model"] == "gpt-oss:120b"
+        assert kwargs["base_url"] == "http://localhost:11434/v1"
+        assert kwargs["api_key"] == "test-key"
         assert kwargs["temperature"] == pytest.approx(0.7)
         assert kwargs["top_p"] == pytest.approx(0.85)
         assert kwargs["strategy_hint"] == "hint"
@@ -247,9 +243,9 @@ class TestPickle:
     """LLMOpponent is pickle-safe (needed for self-play checkpoints)."""
 
     def test_pickle_preserves_model(self) -> None:
-        a = LLMOpponent(model="gpt-4o", timeout=5.0)
+        a = LLMOpponent(model="gpt-oss:20b", timeout=5.0)
         restored = pickle.loads(pickle.dumps(a))
-        assert restored._model == "gpt-4o"
+        assert restored._model == "gpt-oss:20b"
 
     def test_pickle_preserves_temperature(self) -> None:
         a = LLMOpponent(temperature=0.77)

--- a/tests/test_multi_agent_r4.py
+++ b/tests/test_multi_agent_r4.py
@@ -78,10 +78,9 @@ def _fake_http_response(action_index: int) -> unittest.mock.MagicMock:
 _PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 _ENV_EXAMPLE = os.path.join(_PROJECT_ROOT, ".env.example")
 
-_FAKE_AZURE_ENV = {
-    "AZURE_OPENAI_BASE_URL": "https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-    "AZURE_OPENAI_API_KEY": "fake-key-00000000000000000000000000000000",
-    "AZURE_OPENAI_API_VERSION": "2024-02-01",
+_FAKE_OLLAMA_ENV = {
+    "OLLAMA_BASE_URL": "http://localhost:11434/v1",
+    "OLLAMA_API_KEY": "fake-key-00000000000000000000000000000000",
 }
 
 
@@ -395,7 +394,7 @@ def test_when_game_result_is_frozen_then_n_turns_mutation_always_raises(
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Global: .env.example committed
-# Criterion: Azure credentials load from .env; .env.example is committed
+# Criterion: Ollama credentials load from .env; .env.example is committed
 # ══════════════════════════════════════════════════════════════════════════════
 
 
@@ -404,22 +403,16 @@ def test_when_project_root_is_checked_then_env_example_file_is_present():
     assert os.path.isfile(_ENV_EXAMPLE), f".env.example not found at {_ENV_EXAMPLE}"
 
 
-def test_when_env_example_is_read_then_azure_base_url_variable_is_declared():
+def test_when_env_example_is_read_then_ollama_base_url_variable_is_declared():
     with open(_ENV_EXAMPLE) as fh:
         content = fh.read()
-    assert "AZURE_OPENAI_BASE_URL" in content
+    assert "OLLAMA_BASE_URL" in content
 
 
-def test_when_env_example_is_read_then_azure_api_key_variable_is_declared():
+def test_when_env_example_is_read_then_ollama_api_key_variable_is_declared():
     with open(_ENV_EXAMPLE) as fh:
         content = fh.read()
-    assert "AZURE_OPENAI_API_KEY" in content
-
-
-def test_when_env_example_is_read_then_azure_api_version_variable_is_declared():
-    with open(_ENV_EXAMPLE) as fh:
-        content = fh.read()
-    assert "AZURE_OPENAI_API_VERSION" in content
+    assert "OLLAMA_API_KEY" in content
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -447,17 +440,17 @@ def test_when_render_action_prompt_is_called_then_legal_actions_are_represented_
     assert "0" in prompt
 
 
-def test_when_render_action_prompt_is_called_then_azure_api_key_literal_is_absent_from_output():
+def test_when_render_action_prompt_is_called_then_ollama_api_key_literal_is_absent_from_output():
     """Criterion: API key never hardcoded — prompt must not contain the key literal."""
     from src.agents.action_prompt import render_action_prompt
 
     prompt = render_action_prompt(_obs(), [_action()])
-    assert "AZURE_OPENAI_API_KEY" not in prompt
+    assert "OLLAMA_API_KEY" not in prompt
 
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Global: LLM output is index into legal_actions — always legal by construction
-# Criterion: call_azure_for_action_index returns an action from legal_actions
+# Criterion: call_ollama_for_action_index returns an action from legal_actions
 # ══════════════════════════════════════════════════════════════════════════════
 
 
@@ -469,43 +462,43 @@ _LEGAL_SKIP = [
 _SKIP_ACTION = {"action_type": 5, "param_a": 0, "param_b": 0, "param_c": 0, "param_d": 0}
 
 
-def test_when_azure_returns_action_index_0_then_result_is_zero():
+def test_when_ollama_returns_action_index_0_then_result_is_zero():
     """Criterion: index 0 maps to the first element; function returns the index (int)."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION, _SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)),
     ):
-        result = call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        result = call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
     assert result == 0
 
 
-def test_when_azure_returns_action_index_1_then_result_is_one():
+def test_when_ollama_returns_action_index_1_then_result_is_one():
     """Criterion: index 1 maps to the second element; function returns the index (int)."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION, _SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(1)),
     ):
-        result = call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        result = call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
     assert result == 1
 
 
-def test_when_azure_returns_last_valid_index_then_result_equals_last_index():
+def test_when_ollama_returns_last_valid_index_then_result_equals_last_index():
     """Criterion: index at the end of legal_actions is returned as-is."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION] * 5
     last_idx = len(legal) - 1
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(last_idx)),
     ):
-        result = call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        result = call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
     assert result == last_idx
 
 
@@ -516,44 +509,44 @@ def test_when_azure_returns_last_valid_index_then_result_equals_last_index():
     st.integers(min_value=1, max_value=10),  # list length
     st.integers(min_value=0, max_value=9),  # raw index
 )
-def test_when_azure_returns_any_valid_index_then_result_is_always_in_range(
+def test_when_ollama_returns_any_valid_index_then_result_is_always_in_range(
     n_actions: int, raw_index: int
 ) -> None:
     """Return value is always a valid index into legal_actions (int, in-range).
 
     Derived from: 'LLM output is an index into legal_actions — always legal.'
     """
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION] * n_actions
     index = raw_index % n_actions
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(index)),
     ):
-        result = call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        result = call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
     assert result is not None
     assert 0 <= result < n_actions
 
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Global [T2]: LLM calls /chat/completions with json_schema strict response_format
-# Criterion: LLM opponent calls Azure OpenAI GPT-4.1 via /chat/completions
+# Criterion: LLM opponent calls Ollama via /chat/completions
 #            with json_schema `strict` output
 # Black-box: capture httpx.post call args and inspect the outgoing request body.
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-def test_when_azure_client_is_called_then_url_contains_chat_completions():
+def test_when_ollama_client_is_called_then_url_contains_chat_completions():
     """URL sent to httpx.post must contain '/chat/completions' (not '/completions')."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     call_args = mock_post.call_args
     url = call_args.args[0] if call_args.args else call_args.kwargs.get("url", "")
@@ -562,34 +555,34 @@ def test_when_azure_client_is_called_then_url_contains_chat_completions():
     )
 
 
-def test_when_azure_client_is_called_then_request_body_includes_response_format():
-    """Request body sent to Azure must include a 'response_format' key."""
-    from src.agents.azure_openai import call_azure_for_action_index
+def test_when_ollama_client_is_called_then_request_body_includes_response_format():
+    """Request body sent to Ollama must include a 'response_format' key."""
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
     assert "response_format" in body, (
-        "Azure request body must include 'response_format' for json_schema strict output"
+        "Ollama request body must include 'response_format' for json_schema strict output"
     )
 
 
-def test_when_azure_client_is_called_then_response_format_type_is_json_schema():
+def test_when_ollama_client_is_called_then_response_format_type_is_json_schema():
     """response_format.type must equal 'json_schema' (not 'json_object' or absent)."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
@@ -599,16 +592,16 @@ def test_when_azure_client_is_called_then_response_format_type_is_json_schema():
     )
 
 
-def test_when_azure_client_is_called_then_json_schema_strict_is_true():
+def test_when_ollama_client_is_called_then_json_schema_strict_is_true():
     """response_format.json_schema.strict must be True to enforce exact schema output."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
@@ -616,16 +609,16 @@ def test_when_azure_client_is_called_then_json_schema_strict_is_true():
     assert json_schema_def.get("strict") is True, "response_format.json_schema.strict must be True"
 
 
-def test_when_azure_client_is_called_then_schema_enforces_action_index_field():
+def test_when_ollama_client_is_called_then_schema_enforces_action_index_field():
     """json_schema properties must include 'action_index' so the LLM picks an index."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
@@ -641,21 +634,21 @@ def test_when_azure_client_is_called_then_schema_enforces_action_index_field():
 
 
 @given(st.integers(min_value=1, max_value=10))
-def test_when_azure_is_called_with_any_n_actions_then_response_format_is_json_schema(
+def test_when_ollama_is_called_with_any_n_actions_then_response_format_is_json_schema(
     n_actions: int,
 ) -> None:
     """response_format.type is always 'json_schema' regardless of legal_actions size.
 
-    Derived from: 'calls Azure via /chat/completions with json_schema strict output'.
+    Derived from: 'calls Ollama via /chat/completions with json_schema strict output'.
     """
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION] * n_actions
     with (
-        unittest.mock.patch.dict(os.environ, _FAKE_AZURE_ENV),
+        unittest.mock.patch.dict(os.environ, _FAKE_OLLAMA_ENV),
         unittest.mock.patch("httpx.post", return_value=_fake_http_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_obs(), legal, model="gpt-4.1")
+        call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     body = mock_post.call_args.kwargs.get("json") or {}
     assert body.get("response_format", {}).get("type") == "json_schema"

--- a/tests/test_ollama_acceptance.py
+++ b/tests/test_ollama_acceptance.py
@@ -1,4 +1,4 @@
-"""Acceptance tests for issue #59: LLMOpponent on Azure backend.
+"""Acceptance tests for issue #59: LLMOpponent on Ollama backend.
 
 30 s timeout, random fallback, per-call sampling, pickle-safe.
 One named test per verifiable LLM acceptance criterion.
@@ -20,9 +20,9 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from src.agents.action_prompt import render_action_prompt
-from src.agents.azure_openai import AzureConfigError, call_azure_for_action_index
 from src.agents.base import Agent
 from src.agents.llm_opponent import LLMOpponent
+from src.agents.ollama_client import call_ollama_for_action_index
 from src.agents.player_config import PlayerConfig
 
 # ---------------------------------------------------------------------------
@@ -30,19 +30,18 @@ from src.agents.player_config import PlayerConfig
 # ---------------------------------------------------------------------------
 
 _CREDS = {
-    "AZURE_OPENAI_BASE_URL": "https://fake.openai.azure.com/openai/deployments/gpt-4.1",
-    "AZURE_OPENAI_API_KEY": "test-key-00000000",
-    "AZURE_OPENAI_API_VERSION": "2024-12-01",
+    "OLLAMA_BASE_URL": "http://fake-ollama.local/v1",
+    "OLLAMA_API_KEY": "test-key-00000000",
 }
 
-_FAKE_OBS: dict = {}  # acceptable for azure-client tests (render_action_prompt mocked)
+_FAKE_OBS: dict = {}  # acceptable for ollama-client tests (render_action_prompt mocked)
 
 
 def _cfg(**overrides) -> PlayerConfig:
     return PlayerConfig(
         **{
             "player_id": 0,
-            "model": "gpt-4.1",
+            "model": "gpt-oss:120b",
             "temperature": 0.5,
             "top_p": 0.9,
             "strategy_hint": "Play greedily.",
@@ -72,20 +71,22 @@ def env_data():
 
 # ---------------------------------------------------------------------------
 # 1. json_schema strict
-#    Criterion: LLM opponent calls Azure GPT-4.1 via /chat/completions with
+#    Criterion: LLM opponent calls Ollama via /chat/completions with
 #               json_schema strict output.
 # ---------------------------------------------------------------------------
 
 
 def test_when_choose_action_called_then_request_uses_json_schema_strict():
-    """Azure request body must declare response_format.type='json_schema' with strict=True."""
+    """Ollama request body must declare response_format.type='json_schema' with strict=True."""
     with (
         patch.dict(os.environ, _CREDS, clear=False),
-        patch("src.agents.azure_openai.ensure_env_loaded"),
-        patch("src.agents.azure_openai.render_action_prompt", return_value="prompt"),
-        patch("src.agents.azure_openai.httpx.post", return_value=_ok_response(0)) as mock_post,
+        patch("src.agents.ollama_client.ensure_env_loaded"),
+        patch("src.agents.ollama_client.render_action_prompt", return_value="prompt"),
+        patch("src.agents.ollama_client.httpx.post", return_value=_ok_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_FAKE_OBS, ["a"], model="gpt-4.1", temperature=0.5, top_p=0.9)
+        call_ollama_for_action_index(
+            _FAKE_OBS, ["a"], model="gpt-oss:120b", temperature=0.5, top_p=0.9
+        )
 
     body = mock_post.call_args.kwargs["json"]
     rf = body.get("response_format", {})
@@ -95,7 +96,7 @@ def test_when_choose_action_called_then_request_uses_json_schema_strict():
 
 # ---------------------------------------------------------------------------
 # 2. Per-call temperature / top_p in body
-#    Criterion: per-call temperature/top_p reach the Azure request body.
+#    Criterion: per-call temperature/top_p reach the Ollama request body.
 # ---------------------------------------------------------------------------
 
 
@@ -103,11 +104,13 @@ def test_when_choose_action_called_then_temperature_and_top_p_are_in_request_bod
     """PlayerConfig temperature and top_p must appear verbatim in the POST body."""
     with (
         patch.dict(os.environ, _CREDS, clear=False),
-        patch("src.agents.azure_openai.ensure_env_loaded"),
-        patch("src.agents.azure_openai.render_action_prompt", return_value="prompt"),
-        patch("src.agents.azure_openai.httpx.post", return_value=_ok_response(0)) as mock_post,
+        patch("src.agents.ollama_client.ensure_env_loaded"),
+        patch("src.agents.ollama_client.render_action_prompt", return_value="prompt"),
+        patch("src.agents.ollama_client.httpx.post", return_value=_ok_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_FAKE_OBS, ["a"], model="gpt-4.1", temperature=0.3, top_p=0.85)
+        call_ollama_for_action_index(
+            _FAKE_OBS, ["a"], model="gpt-oss:120b", temperature=0.3, top_p=0.85
+        )
 
     body = mock_post.call_args.kwargs["json"]
     assert body["temperature"] == pytest.approx(0.3)
@@ -125,14 +128,14 @@ def test_when_any_valid_temperature_and_top_p_then_both_reach_request_body(
     """Property: for any valid (temperature, top_p), both reach the body unchanged."""
     with (
         patch.dict(os.environ, _CREDS, clear=False),
-        patch("src.agents.azure_openai.ensure_env_loaded"),
-        patch("src.agents.azure_openai.render_action_prompt", return_value="prompt"),
-        patch("src.agents.azure_openai.httpx.post", return_value=_ok_response(0)) as mock_post,
+        patch("src.agents.ollama_client.ensure_env_loaded"),
+        patch("src.agents.ollama_client.render_action_prompt", return_value="prompt"),
+        patch("src.agents.ollama_client.httpx.post", return_value=_ok_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(
+        call_ollama_for_action_index(
             _FAKE_OBS,
             ["a"],
-            model="gpt-4.1",
+            model="gpt-oss:120b",
             temperature=temperature,
             top_p=top_p,
         )
@@ -171,7 +174,7 @@ def test_when_strategy_hint_provided_then_hint_appears_before_legal_actions_in_p
 
 # ---------------------------------------------------------------------------
 # 4. Timeout → fallback
-#    Criterion: ≤ 30s hard timeout; falls back to RandomAgent on timeout.
+#    Criterion: <= 30s hard timeout; falls back to RandomAgent on timeout.
 # ---------------------------------------------------------------------------
 
 
@@ -230,44 +233,63 @@ def test_when_out_of_range_index_returned_then_fallback_returns_legal_action(env
 
 
 # ---------------------------------------------------------------------------
-# 8. Config error when credentials are unresolved
-#    Criterion: config error when creds unresolved.
+# 8. Default-fallback behavior when credentials are unset
+#    Criterion: local Ollama needs no key — missing creds fall back to defaults,
+#    never raise. (Old AzureConfigError no longer exists.)
 # ---------------------------------------------------------------------------
 
 
-def test_when_credentials_not_configured_then_config_error_is_raised(monkeypatch):
-    """Missing Azure credentials must raise AzureConfigError before any HTTP call."""
-    monkeypatch.delenv("AZURE_OPENAI_BASE_URL", raising=False)
-    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("AZURE_OPENAI_API_VERSION", raising=False)
+def test_when_credentials_not_configured_then_defaults_are_used_and_no_error_raised():
+    """Missing OLLAMA_BASE_URL / OLLAMA_API_KEY must NOT raise; client falls back to defaults."""
     with (
-        patch("src.agents.azure_openai.ensure_env_loaded"),
-        pytest.raises(AzureConfigError),
+        patch.dict(os.environ, {}, clear=True),
+        patch("src.agents.ollama_client.ensure_env_loaded"),
+        patch("src.agents.ollama_client.render_action_prompt", return_value="prompt"),
+        patch("src.agents.ollama_client.httpx.post", return_value=_ok_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_FAKE_OBS, ["a"], model="gpt-4.1", temperature=0.5, top_p=0.9)
+        # Should not raise — unlike the old Azure client
+        result = call_ollama_for_action_index(
+            _FAKE_OBS, ["a"], model="gpt-oss:120b", temperature=0.5, top_p=0.9
+        )
+
+    assert result == 0
+    url = mock_post.call_args.args[0]
+    assert url.startswith("http://localhost:11434/v1"), (
+        f"Expected localhost default URL, got: {url!r}"
+    )
+    headers = mock_post.call_args.kwargs["headers"]
+    assert headers.get("Authorization") == "Bearer ollama", (
+        f"Expected default 'Bearer ollama', got: {headers.get('Authorization')!r}"
+    )
 
 
 # ---------------------------------------------------------------------------
-# 9. URL ends /chat/completions?api-version=... with api-key header
-#    Criterion: URL format + api-key header.
+# 9. URL ends /chat/completions with Authorization: Bearer header
+#    Criterion: URL format + Authorization: Bearer header (no api-version, no api-key).
 # ---------------------------------------------------------------------------
 
 
-def test_when_request_sent_url_contains_chat_completions_api_version_and_api_key_header():
-    """POST URL must contain /chat/completions?api-version=...; api-key header required."""
+def test_when_request_sent_url_contains_chat_completions_and_bearer_auth_header():
+    """POST URL must contain /chat/completions; Authorization: Bearer header required."""
     with (
         patch.dict(os.environ, _CREDS, clear=False),
-        patch("src.agents.azure_openai.ensure_env_loaded"),
-        patch("src.agents.azure_openai.render_action_prompt", return_value="prompt"),
-        patch("src.agents.azure_openai.httpx.post", return_value=_ok_response(0)) as mock_post,
+        patch("src.agents.ollama_client.ensure_env_loaded"),
+        patch("src.agents.ollama_client.render_action_prompt", return_value="prompt"),
+        patch("src.agents.ollama_client.httpx.post", return_value=_ok_response(0)) as mock_post,
     ):
-        call_azure_for_action_index(_FAKE_OBS, ["a"], model="gpt-4.1", temperature=0.5, top_p=0.9)
+        call_ollama_for_action_index(
+            _FAKE_OBS, ["a"], model="gpt-oss:120b", temperature=0.5, top_p=0.9
+        )
 
     url: str = mock_post.call_args.args[0]
     headers: dict = mock_post.call_args.kwargs["headers"]
     assert "/chat/completions" in url, f"URL {url!r} missing '/chat/completions'"
-    assert "api-version=" in url, f"URL {url!r} missing 'api-version=' query param"
-    assert "api-key" in headers, f"'api-key' header missing; got: {list(headers)}"
+    assert "api-version=" not in url, f"URL {url!r} must NOT contain 'api-version='"
+    assert "Authorization" in headers, f"'Authorization' header missing; got: {list(headers)}"
+    assert headers["Authorization"].startswith("Bearer "), (
+        f"Authorization header must be Bearer token, got: {headers['Authorization']!r}"
+    )
+    assert "api-key" not in headers, f"Old 'api-key' header must be absent; got: {list(headers)}"
 
 
 # ---------------------------------------------------------------------------
@@ -291,10 +313,10 @@ def test_when_legal_actions_empty_then_value_error_is_raised(env_data):
 
 def test_when_pickle_roundtrip_then_attributes_preserved_and_agent_protocol_satisfied():
     """Pickle/unpickle must preserve _model, _temperature, _strategy_hint and Agent protocol."""
-    cfg = _cfg(model="gpt-4.1", temperature=0.7, strategy_hint="unique-hint-abc")
+    cfg = _cfg(model="gpt-oss:120b", temperature=0.7, strategy_hint="unique-hint-abc")
     restored: LLMOpponent = pickle.loads(pickle.dumps(LLMOpponent(player_config=cfg)))
     assert isinstance(restored, Agent)
-    assert restored._model == "gpt-4.1"
+    assert restored._model == "gpt-oss:120b"
     assert restored._temperature == pytest.approx(0.7)
     assert restored._strategy_hint == "unique-hint-abc"
 
@@ -307,7 +329,7 @@ def test_when_pickle_roundtrip_then_attributes_preserved_and_agent_protocol_sati
 
 def test_when_player_config_provided_then_config_params_override_scalar_kwargs():
     """PlayerConfig values must take precedence over contradicting constructor scalar kwargs."""
-    cfg = _cfg(model="gpt-4.1", temperature=0.1, top_p=0.95, strategy_hint="Config hint")
+    cfg = _cfg(model="gpt-oss:120b", temperature=0.1, top_p=0.95, strategy_hint="Config hint")
     opponent = LLMOpponent(
         player_config=cfg,
         model="old-model",
@@ -315,7 +337,7 @@ def test_when_player_config_provided_then_config_params_override_scalar_kwargs()
         top_p=0.01,
         strategy_hint="Scalar hint",
     )
-    assert opponent._model == "gpt-4.1"
+    assert opponent._model == "gpt-oss:120b"
     assert opponent._temperature == pytest.approx(0.1)
     assert opponent._top_p == pytest.approx(0.95)
     assert opponent._strategy_hint == "Config hint"
@@ -354,16 +376,15 @@ def test_when_fallback_triggered_then_returned_action_is_always_in_legal_actions
 
 # ---------------------------------------------------------------------------
 # 14. .env.example committed with required variable names
-#     Criterion: Azure credentials load from git-ignored .env; .env.example committed.
+#     Criterion: Ollama credentials load from git-ignored .env; .env.example committed.
 # ---------------------------------------------------------------------------
 
 
 def test_when_env_example_committed_then_all_required_variable_names_are_present():
-    """.env.example at project root must list all three Azure credential variable names."""
+    """.env.example at project root must list all Ollama credential variable names."""
     project_root = Path(__file__).resolve().parent.parent
     env_example = project_root / ".env.example"
     assert env_example.exists(), f".env.example not found at {project_root}"
     content = env_example.read_text()
-    assert "AZURE_OPENAI_BASE_URL" in content
-    assert "AZURE_OPENAI_API_KEY" in content
-    assert "AZURE_OPENAI_API_VERSION" in content
+    assert "OLLAMA_BASE_URL" in content
+    assert "OLLAMA_API_KEY" in content

--- a/tests/test_ollama_api_contract.py
+++ b/tests/test_ollama_api_contract.py
@@ -1,10 +1,10 @@
-"""Spec-derived tests for issue #58 — Azure API contract and render_action_prompt.
+"""Spec-derived tests for issue #58 — Ollama API contract and render_action_prompt.
 
 Criteria covered:
-  [T2]   LLM opponent calls Azure OpenAI GPT-4.1 via /chat/completions
+  [T2]   LLM opponent calls Ollama via /chat/completions
          with json_schema strict output
-  [UNIT] Azure credentials load from a git-ignored .env
-         (AZURE_OPENAI_BASE_URL / _API_KEY / _API_VERSION); .env.example committed
+  [UNIT] Ollama credentials load from a git-ignored .env
+         (OLLAMA_BASE_URL / OLLAMA_API_KEY); .env.example committed
   [UNIT] LLM output is an index into legal_actions — chosen action always legal
   [UNIT] render_action_prompt() is the single source of truth for the LLM prompt;
          the API key is never hardcoded in source
@@ -24,7 +24,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from src.agents.action_prompt import render_action_prompt
-from src.agents.azure_openai import call_azure_for_action_index
+from src.agents.ollama_client import call_ollama_for_action_index
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent
 
@@ -33,9 +33,8 @@ PROJECT_ROOT = pathlib.Path(__file__).parent.parent
 # ────────────────────────────────────────────────────────────────────────────
 
 _FAKE_ENV = {
-    "AZURE_OPENAI_BASE_URL": "https://test.openai.azure.com/openai/deployments/gpt-4.1",
-    "AZURE_OPENAI_API_KEY": "test-api-key-abc123",
-    "AZURE_OPENAI_API_VERSION": "2024-02-01",
+    "OLLAMA_BASE_URL": "http://fake-ollama.local/v1",
+    "OLLAMA_API_KEY": "test-api-key-abc123",
 }
 
 _N_TERRITORIES = 42
@@ -70,7 +69,7 @@ def _make_mock_response(action_index: int) -> MagicMock:
     return resp
 
 
-def _call_azure(
+def _call_ollama(
     legal_actions: list[dict[str, int]],
     action_index: int = 0,
     temperature: float = 0.5,
@@ -79,7 +78,7 @@ def _call_azure(
     env: dict[str, str] | None = None,
     obs: dict[str, np.ndarray] | None = None,
 ) -> tuple[int | None, list[Any]]:
-    """Call call_azure_for_action_index with a patched httpx.post.
+    """Call call_ollama_for_action_index with a patched httpx.post.
 
     Returns (result, captured_call_args_list).
     """
@@ -95,10 +94,10 @@ def _call_azure(
         patch.dict(os.environ, env or _FAKE_ENV),
         patch("httpx.post", side_effect=fake_post),
     ):
-        result = call_azure_for_action_index(
+        result = call_ollama_for_action_index(
             obs,
             legal_actions,
-            model="gpt-4.1",
+            model="gpt-oss:120b",
             temperature=temperature,
             top_p=top_p,
             strategy_hint=strategy_hint,
@@ -111,55 +110,61 @@ def _call_azure(
 # ────────────────────────────────────────────────────────────────────────────
 
 
-class TestAzureChatCompletionsEndpoint:
-    """Azure /chat/completions endpoint and json_schema strict contract."""
+class TestOllamaChatCompletionsEndpoint:
+    """Ollama /chat/completions endpoint and json_schema strict contract."""
 
-    def test_when_llm_called_then_exactly_one_http_request_is_made(self):
+    def test_when_ollama_called_then_exactly_one_http_request_is_made(self):
         """Criterion: the client makes exactly one call per move."""
-        _, calls = _call_azure([_skip_action()])
+        _, calls = _call_ollama([_skip_action()])
         assert len(calls) == 1
 
-    def test_when_llm_called_then_request_url_contains_chat_completions(self):
-        """Criterion: LLM opponent calls Azure OpenAI via /chat/completions."""
-        _, calls = _call_azure([_skip_action()])
+    def test_when_ollama_called_then_request_url_contains_chat_completions(self):
+        """Criterion: LLM opponent calls Ollama via /chat/completions."""
+        _, calls = _call_ollama([_skip_action()])
         url = calls[0]["url"]
         assert "/chat/completions" in url, f"Expected /chat/completions in URL, got: {url}"
 
-    def test_when_llm_called_then_request_body_uses_json_schema_response_format(self):
+    def test_when_ollama_called_then_request_url_does_not_contain_api_version(self):
+        """Criterion: Ollama URL has no api-version query parameter."""
+        _, calls = _call_ollama([_skip_action()])
+        url = calls[0]["url"]
+        assert "api-version=" not in url, f"URL must not contain api-version, got: {url}"
+
+    def test_when_ollama_called_then_request_body_uses_json_schema_response_format(self):
         """Criterion: response_format type must be 'json_schema'."""
-        _, calls = _call_azure([_skip_action(), _skip_action()])
+        _, calls = _call_ollama([_skip_action(), _skip_action()])
         body = calls[0]["kwargs"]["json"]
         rf = body.get("response_format", {})
         assert rf.get("type") == "json_schema", (
             f"response_format.type must be 'json_schema', got: {rf}"
         )
 
-    def test_when_llm_called_then_json_schema_strict_is_true(self):
+    def test_when_ollama_called_then_json_schema_strict_is_true(self):
         """Criterion: json_schema strict must be True (enforces output shape)."""
-        _, calls = _call_azure([_skip_action()])
+        _, calls = _call_ollama([_skip_action()])
         body = calls[0]["kwargs"]["json"]
         rf = body.get("response_format", {})
         inner = rf.get("json_schema", {})
         assert inner.get("strict") is True, f"json_schema.strict must be True, got: {inner}"
 
-    def test_when_llm_called_then_request_body_contains_action_index_schema(self):
+    def test_when_ollama_called_then_request_body_contains_action_index_schema(self):
         """The json_schema must constrain the output to contain 'action_index'."""
-        _, calls = _call_azure([_skip_action()])
+        _, calls = _call_ollama([_skip_action()])
         body = calls[0]["kwargs"]["json"]
         raw_schema = json.dumps(body)
         assert "action_index" in raw_schema, "The request schema must reference 'action_index'"
 
     def test_when_temperature_supplied_then_it_appears_in_request_body(self):
-        """Criterion: per-call temperature injected into the Azure request body."""
-        _, calls = _call_azure([_skip_action()], temperature=0.3)
+        """Criterion: per-call temperature injected into the Ollama request body."""
+        _, calls = _call_ollama([_skip_action()], temperature=0.3)
         body = calls[0]["kwargs"]["json"]
         assert body.get("temperature") == pytest.approx(0.3), (
             "temperature must be forwarded to the request body"
         )
 
     def test_when_top_p_supplied_then_it_appears_in_request_body(self):
-        """Criterion: per-call top_p injected into the Azure request body."""
-        _, calls = _call_azure([_skip_action()], top_p=0.85)
+        """Criterion: per-call top_p injected into the Ollama request body."""
+        _, calls = _call_ollama([_skip_action()], top_p=0.85)
         body = calls[0]["kwargs"]["json"]
         assert body.get("top_p") == pytest.approx(0.85), (
             "top_p must be forwarded to the request body"
@@ -174,27 +179,27 @@ class TestAzureChatCompletionsEndpoint:
 class TestActionIndexLegality:
     """LLM returns an in-range index; the resolved action is always legal."""
 
-    def test_when_llm_returns_index_0_then_result_is_zero(self):
+    def test_when_ollama_returns_index_0_then_result_is_zero(self):
         """Criterion: LLM output is an index into legal_actions."""
         legal = [_skip_action(), _skip_action(), _skip_action()]
-        result, _ = _call_azure(legal, action_index=0)
+        result, _ = _call_ollama(legal, action_index=0)
         assert result == 0
 
-    def test_when_llm_returns_index_1_then_result_is_one(self):
+    def test_when_ollama_returns_index_1_then_result_is_one(self):
         legal = [_skip_action(), _skip_action(), _skip_action()]
-        result, _ = _call_azure(legal, action_index=1)
+        result, _ = _call_ollama(legal, action_index=1)
         assert result == 1
 
     def test_when_action_index_in_range_then_result_is_that_index(self):
         """Criterion: the returned index is always in [0, len(legal_actions))."""
         legal = [_skip_action(), _skip_action(), _skip_action()]
-        result, _ = _call_azure(legal, action_index=2)
+        result, _ = _call_ollama(legal, action_index=2)
         assert result == 2
 
     def test_when_returned_index_used_then_resolved_action_is_legal(self):
         """Criterion: the chosen action is always legal by construction."""
         legal = [_skip_action(), _skip_action()]
-        result, _ = _call_azure(legal, action_index=0)
+        result, _ = _call_ollama(legal, action_index=0)
         assert result is not None
         assert 0 <= result < len(legal)
 
@@ -212,56 +217,87 @@ class TestActionIndexLegality:
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# Azure credentials — loaded from environment variables, not hardcoded
+# Ollama credentials — loaded from environment variables, not hardcoded
 # ────────────────────────────────────────────────────────────────────────────
 
 
-class TestAzureCredentialsFromEnv:
-    """Azure credentials come from env vars; .env.example is committed."""
+class TestOllamaCredentialsFromEnv:
+    """Ollama credentials come from env vars; .env.example is committed."""
 
-    def test_when_api_key_env_var_set_then_request_header_contains_it(self):
-        """Criterion: API key comes from AZURE_OPENAI_API_KEY (auth via api-key header)."""
+    def test_when_api_key_env_var_set_then_request_header_contains_bearer_token(self):
+        """Criterion: API key from OLLAMA_API_KEY forwarded as Authorization: Bearer."""
         expected_key = "my-secret-key-xyz"
-        env = {**_FAKE_ENV, "AZURE_OPENAI_API_KEY": expected_key}
-        _, calls = _call_azure([_skip_action()], env=env)
+        env = {**_FAKE_ENV, "OLLAMA_API_KEY": expected_key}
+        _, calls = _call_ollama([_skip_action()], env=env)
         headers = calls[0]["kwargs"].get("headers", {})
-        assert expected_key in headers.values(), (
-            "AZURE_OPENAI_API_KEY must be forwarded in request headers"
+        assert f"Bearer {expected_key}" in headers.values(), (
+            "OLLAMA_API_KEY must be forwarded as 'Authorization: Bearer <key>'"
         )
 
-    def test_when_base_url_env_var_set_then_request_url_starts_with_it(self):
-        """Criterion: AZURE_OPENAI_BASE_URL determines the request endpoint."""
-        base = "https://custom.openai.azure.com/openai/deployments/gpt-4.1"
-        env = {**_FAKE_ENV, "AZURE_OPENAI_BASE_URL": base}
-        _, calls = _call_azure([_skip_action()], env=env)
-        assert calls[0]["url"].startswith(base), "Request URL must start with AZURE_OPENAI_BASE_URL"
+    def test_when_api_key_env_var_set_then_no_api_key_header_is_present(self):
+        """The old api-key header must not be set; only Authorization: Bearer is used."""
+        _, calls = _call_ollama([_skip_action()])
+        headers = calls[0]["kwargs"].get("headers", {})
+        assert "api-key" not in headers, "The api-key header must not be present in Ollama requests"
 
-    def test_when_api_version_env_var_set_then_request_url_contains_it(self):
-        """Criterion: AZURE_OPENAI_API_VERSION appears in the request URL."""
-        version = "2024-05-01-preview"
-        env = {**_FAKE_ENV, "AZURE_OPENAI_API_VERSION": version}
-        _, calls = _call_azure([_skip_action()], env=env)
-        assert version in calls[0]["url"], "AZURE_OPENAI_API_VERSION must appear in the request URL"
+    def test_when_base_url_env_var_set_then_request_url_starts_with_it(self):
+        """Criterion: OLLAMA_BASE_URL determines the request endpoint."""
+        base = "http://custom-ollama.local/v1"
+        env = {**_FAKE_ENV, "OLLAMA_BASE_URL": base}
+        _, calls = _call_ollama([_skip_action()], env=env)
+        assert calls[0]["url"].startswith(base), "Request URL must start with OLLAMA_BASE_URL"
+
+    def test_when_no_env_vars_set_then_request_url_defaults_to_localhost(self):
+        """Criterion: missing OLLAMA_BASE_URL falls back to localhost without raising."""
+        captured: list[Any] = []
+
+        def fake_post(url: str, **kwargs: Any) -> MagicMock:
+            captured.append({"url": url, "kwargs": kwargs})
+            return _make_mock_response(0)
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("httpx.post", side_effect=fake_post),
+        ):
+            call_ollama_for_action_index(_make_obs(), [_skip_action()], model="gpt-oss:120b")
+
+        assert captured[0]["url"].startswith("http://localhost:11434/v1"), (
+            "Default base URL must be http://localhost:11434/v1"
+        )
+
+    def test_when_no_api_key_env_var_then_authorization_header_is_bearer_ollama(self):
+        """Criterion: missing OLLAMA_API_KEY defaults to 'Bearer ollama', never raises."""
+        captured: list[Any] = []
+
+        def fake_post(url: str, **kwargs: Any) -> MagicMock:
+            captured.append({"url": url, "kwargs": kwargs})
+            return _make_mock_response(0)
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("httpx.post", side_effect=fake_post),
+        ):
+            call_ollama_for_action_index(_make_obs(), [_skip_action()], model="gpt-oss:120b")
+
+        headers = captured[0]["kwargs"].get("headers", {})
+        assert headers.get("Authorization") == "Bearer ollama", (
+            "Default Authorization header must be 'Bearer ollama'"
+        )
 
     def test_when_dot_env_example_checked_then_file_exists_at_project_root(self):
         """Criterion: .env.example is committed (exists in the repository root)."""
         env_example = PROJECT_ROOT / ".env.example"
         assert env_example.exists(), ".env.example must be committed at the project root"
 
-    def test_when_dot_env_example_read_then_azure_base_url_key_is_present(self):
-        """Criterion: .env.example documents AZURE_OPENAI_BASE_URL."""
+    def test_when_dot_env_example_read_then_ollama_base_url_key_is_present(self):
+        """Criterion: .env.example documents OLLAMA_BASE_URL."""
         content = (PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_BASE_URL" in content
+        assert "OLLAMA_BASE_URL" in content
 
-    def test_when_dot_env_example_read_then_azure_api_key_key_is_present(self):
-        """Criterion: .env.example documents AZURE_OPENAI_API_KEY."""
+    def test_when_dot_env_example_read_then_ollama_api_key_key_is_present(self):
+        """Criterion: .env.example documents OLLAMA_API_KEY."""
         content = (PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_API_KEY" in content
-
-    def test_when_dot_env_example_read_then_azure_api_version_key_is_present(self):
-        """Criterion: .env.example documents AZURE_OPENAI_API_VERSION."""
-        content = (PROJECT_ROOT / ".env.example").read_text()
-        assert "AZURE_OPENAI_API_VERSION" in content
+        assert "OLLAMA_API_KEY" in content
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -300,23 +336,23 @@ class TestRenderActionPrompt:
     def test_when_called_then_output_does_not_contain_an_api_key_pattern(self):
         """Criterion: the API key is never hardcoded in source."""
         fake_key = "do-not-leak-this-key-abc987"
-        with patch.dict(os.environ, {"AZURE_OPENAI_API_KEY": fake_key}):
+        with patch.dict(os.environ, {"OLLAMA_API_KEY": fake_key}):
             result = render_action_prompt(_make_obs(), [_skip_action()])
         assert fake_key not in result, "render_action_prompt must not embed the API key"
 
-    def test_when_called_then_azure_client_uses_its_output_as_message_content(self):
+    def test_when_called_then_ollama_client_uses_its_output_as_message_content(self):
         """Criterion: render_action_prompt() is the single source of truth."""
         obs = _make_obs()
         legal = [_skip_action()]
         hint = "Be aggressive."
 
         expected = render_action_prompt(obs, legal, strategy_hint=hint)
-        _, calls = _call_azure(legal, strategy_hint=hint, obs=obs)
+        _, calls = _call_ollama(legal, strategy_hint=hint, obs=obs)
 
         messages = calls[0]["kwargs"]["json"].get("messages", [])
         all_content = " ".join(m.get("content", "") for m in messages)
         assert expected in all_content, (
-            "Azure request messages must contain the render_action_prompt() output"
+            "Ollama request messages must contain the render_action_prompt() output"
         )
 
     @given(st.integers(min_value=0, max_value=5))

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,14 +1,16 @@
-"""Source-blind example tests for src.agents.azure_openai — Issue #56.
+"""Source-blind example tests for src.agents.ollama_client — migrated from Azure contract.
 
 Derived exclusively from acceptance criteria; no implementation source was read.
 All HTTP calls and env-loading are mocked. No real .env is read.
 
 Criteria covered:
-- call_azure_for_action_index() POSTs to /chat/completions?api-version=...
-  with the api-key header and response_format json_schema strict:true
+- call_ollama_for_action_index() POSTs to {base}/chat/completions with NO api-version query string
+- Auth uses Authorization: Bearer <key> header (NOT api-key)
+- Request body sets response_format json_schema with strict:true
 - Returns an index in [0, len(legal_actions)) or None on empty/unparseable/out-of-range reply
 - Per-call temperature and top_p injected verbatim; top_p omitted when None
-- Raises AzureConfigError when AZURE_OPENAI_BASE_URL or AZURE_OPENAI_API_KEY is unresolved
+- When OLLAMA_BASE_URL / OLLAMA_API_KEY are unset, falls back to defaults (localhost + "ollama")
+  — AzureConfigError no longer exists; missing creds are never an error
 """
 
 from __future__ import annotations
@@ -24,17 +26,17 @@ from hypothesis import strategies as st
 # Shared test doubles
 # ──────────────────────────────────────────────────────────────────────────────
 
-_FAKE_BASE_URL = "https://fake.openai.azure.com/openai/deployments/gpt-4.1"
+_FAKE_BASE_URL = "http://fake-ollama.local/v1"
 _FAKE_API_KEY = "test-key-never-commit-this"
-_FAKE_API_VERSION = "2024-02-15-preview"
 
 _FAKE_ENV = {
-    "AZURE_OPENAI_BASE_URL": _FAKE_BASE_URL,
-    "AZURE_OPENAI_API_KEY": _FAKE_API_KEY,
-    "AZURE_OPENAI_API_VERSION": _FAKE_API_VERSION,
+    "OLLAMA_BASE_URL": _FAKE_BASE_URL,
+    "OLLAMA_API_KEY": _FAKE_API_KEY,
 }
 
 _FAKE_OBS: dict = {}  # minimal placeholder; real obs built by env internally
+
+_DEFAULT_MODEL = "gpt-oss:120b"
 
 
 @pytest.fixture(autouse=True)
@@ -45,8 +47,8 @@ def _no_dotenv():
     it keeps these tests focused purely on the HTTP-client contract.
     """
     with (
-        patch("src.agents.azure_openai.ensure_env_loaded", return_value=None),
-        patch("src.agents.azure_openai.render_action_prompt", return_value="fake prompt"),
+        patch("src.agents.ollama_client.ensure_env_loaded", return_value=None),
+        patch("src.agents.ollama_client.render_action_prompt", return_value="fake prompt"),
     ):
         yield
 
@@ -68,9 +70,6 @@ def _resp(action_index: int | None = 0) -> MagicMock:
     return _fake_response(json.dumps({"action_index": action_index}))
 
 
-_DEFAULT_MODEL = "gpt-4.1"
-
-
 def _call(
     legal_actions: list,
     *,
@@ -79,17 +78,17 @@ def _call(
     resp: MagicMock | None = None,
     model: str = _DEFAULT_MODEL,
 ):
-    """Invoke call_azure_for_action_index() with all I/O mocked."""
-    from src.agents.azure_openai import call_azure_for_action_index
+    """Invoke call_ollama_for_action_index() with all I/O mocked."""
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     if resp is None:
         resp = _resp(0)
 
     with (
         patch.dict("os.environ", _FAKE_ENV, clear=False),
-        patch("src.agents.azure_openai.httpx.post", return_value=resp) as mock_post,
+        patch("src.agents.ollama_client.httpx.post", return_value=resp) as mock_post,
     ):
-        result = call_azure_for_action_index(
+        result = call_ollama_for_action_index(
             _FAKE_OBS,
             legal_actions,
             model=model,
@@ -104,8 +103,8 @@ def _call(
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def test_when_called_then_posts_to_url_containing_chat_completions():
-    """call_azure_for_action_index() must POST to a URL containing /chat/completions."""
+def test_when_ollama_called_then_posts_to_url_containing_chat_completions():
+    """call_ollama_for_action_index() must POST to a URL containing /chat/completions."""
     _, mock_post = _call(["a", "b"])
 
     assert mock_post.called
@@ -113,23 +112,31 @@ def test_when_called_then_posts_to_url_containing_chat_completions():
     assert "/chat/completions" in url
 
 
-def test_when_called_then_url_contains_api_version_query_param():
-    """The POST URL must include an api-version= query parameter."""
+def test_when_ollama_called_then_url_does_not_contain_api_version_query_param():
+    """The POST URL must NOT include an api-version= query parameter (Ollama has none)."""
     _, mock_post = _call(["a", "b"])
 
     url = mock_post.call_args.args[0]
-    assert "api-version=" in url
+    assert "api-version=" not in url
 
 
-def test_when_called_then_api_key_header_equals_env_var():
-    """The api-key request header must equal AZURE_OPENAI_API_KEY from env."""
+def test_when_ollama_called_then_authorization_bearer_header_equals_env_var():
+    """The Authorization: Bearer header must equal OLLAMA_API_KEY from env."""
     _, mock_post = _call(["a", "b"])
 
     headers = mock_post.call_args.kwargs.get("headers", {})
-    assert headers.get("api-key") == _FAKE_API_KEY
+    assert headers.get("Authorization") == f"Bearer {_FAKE_API_KEY}"
 
 
-def test_when_called_then_response_format_type_is_json_schema():
+def test_when_ollama_called_then_no_api_key_header_is_set():
+    """The old api-key header must NOT be present; Ollama uses Authorization: Bearer."""
+    _, mock_post = _call(["a", "b"])
+
+    headers = mock_post.call_args.kwargs.get("headers", {})
+    assert "api-key" not in headers
+
+
+def test_when_ollama_called_then_response_format_type_is_json_schema():
     """Request body must set response_format.type to 'json_schema'."""
     _, mock_post = _call(["a", "b"])
 
@@ -137,7 +144,7 @@ def test_when_called_then_response_format_type_is_json_schema():
     assert body.get("response_format", {}).get("type") == "json_schema"
 
 
-def test_when_called_then_json_schema_strict_is_true():
+def test_when_ollama_called_then_json_schema_strict_is_true():
     """Request body must set response_format.json_schema.strict to True."""
     _, mock_post = _call(["a", "b"])
 
@@ -151,39 +158,39 @@ def test_when_called_then_json_schema_strict_is_true():
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def test_when_model_returns_index_0_then_zero_is_returned():
+def test_when_ollama_returns_index_0_then_zero_is_returned():
     """action_index=0 on a non-empty list must return the integer 0."""
     result, _ = _call(["only_action"], resp=_resp(0))
     assert result == 0
 
 
-def test_when_model_returns_valid_mid_index_then_that_integer_is_returned():
+def test_when_ollama_returns_valid_mid_index_then_that_integer_is_returned():
     """A valid action_index within bounds must be returned unchanged."""
     result, _ = _call(["a", "b", "c"], resp=_resp(2))
     assert result == 2
 
 
-def test_when_model_returns_last_valid_index_then_it_is_returned():
+def test_when_ollama_returns_last_valid_index_then_it_is_returned():
     """action_index == len-1 must succeed (boundary check)."""
     legal = ["x", "y", "z"]
     result, _ = _call(legal, resp=_resp(len(legal) - 1))
     assert result == len(legal) - 1
 
 
-def test_when_model_returns_index_equal_to_len_then_none_is_returned():
+def test_when_ollama_returns_index_equal_to_len_then_none_is_returned():
     """action_index == len(legal_actions) is out-of-range → must return None."""
     legal = ["a", "b"]
     result, _ = _call(legal, resp=_resp(len(legal)))
     assert result is None
 
 
-def test_when_model_returns_index_far_out_of_range_then_none_is_returned():
+def test_when_ollama_returns_index_far_out_of_range_then_none_is_returned():
     """action_index far beyond len must silently return None, not raise."""
     result, _ = _call(["a", "b"], resp=_resp(999))
     assert result is None
 
 
-def test_when_model_returns_negative_index_then_none_is_returned():
+def test_when_ollama_returns_negative_index_then_none_is_returned():
     """Negative action_index must return None (out-of-range by spec)."""
     result, _ = _call(["a", "b", "c"], resp=_resp(-1))
     assert result is None
@@ -237,36 +244,45 @@ def test_when_top_p_is_none_then_top_p_key_is_absent_from_body():
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Credential error propagation
+# Default-fallback behavior when credentials are unset
+# (replaces the old AzureConfigError tests — Ollama never raises on missing creds)
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def test_when_base_url_env_var_missing_then_azure_config_error_is_raised():
-    """Missing AZURE_OPENAI_BASE_URL must raise AzureConfigError before any HTTP call."""
-    from src.agents.azure_openai import AzureConfigError, call_azure_for_action_index
+def test_when_base_url_env_var_missing_then_defaults_to_localhost():
+    """Missing OLLAMA_BASE_URL must fall back to http://localhost:11434/v1, not raise."""
+    from src.agents.ollama_client import call_ollama_for_action_index
 
-    env_no_base = {k: v for k, v in _FAKE_ENV.items() if k != "AZURE_OPENAI_BASE_URL"}
     with (
-        patch.dict("os.environ", env_no_base, clear=True),
-        pytest.raises(AzureConfigError),
+        patch.dict("os.environ", {}, clear=True),
+        patch("src.agents.ollama_client.httpx.post", return_value=_resp(0)) as mock_post,
     ):
-        call_azure_for_action_index(
+        call_ollama_for_action_index(
             _FAKE_OBS, ["a"], model=_DEFAULT_MODEL, temperature=0.5, top_p=0.9
         )
 
+    url = mock_post.call_args.args[0]
+    assert url.startswith("http://localhost:11434/v1"), (
+        f"Expected localhost fallback URL, got: {url!r}"
+    )
 
-def test_when_api_key_env_var_missing_then_azure_config_error_is_raised():
-    """Missing AZURE_OPENAI_API_KEY must raise AzureConfigError before any HTTP call."""
-    from src.agents.azure_openai import AzureConfigError, call_azure_for_action_index
 
-    env_no_key = {k: v for k, v in _FAKE_ENV.items() if k != "AZURE_OPENAI_API_KEY"}
+def test_when_api_key_env_var_missing_then_defaults_to_ollama_bearer():
+    """Missing OLLAMA_API_KEY must fall back to Authorization: Bearer ollama, not raise."""
+    from src.agents.ollama_client import call_ollama_for_action_index
+
     with (
-        patch.dict("os.environ", env_no_key, clear=True),
-        pytest.raises(AzureConfigError),
+        patch.dict("os.environ", {}, clear=True),
+        patch("src.agents.ollama_client.httpx.post", return_value=_resp(0)) as mock_post,
     ):
-        call_azure_for_action_index(
+        call_ollama_for_action_index(
             _FAKE_OBS, ["a"], model=_DEFAULT_MODEL, temperature=0.5, top_p=0.9
         )
+
+    headers = mock_post.call_args.kwargs.get("headers", {})
+    assert headers.get("Authorization") == "Bearer ollama", (
+        f"Expected 'Bearer ollama' fallback, got: {headers.get('Authorization')!r}"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -288,14 +304,14 @@ def test_when_index_in_range_then_that_exact_integer_is_always_returned(n, idx):
     if idx >= n:
         return  # out-of-range covered by example tests above
 
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [f"action_{i}" for i in range(n)]
     with (
         patch.dict("os.environ", _FAKE_ENV, clear=False),
-        patch("src.agents.azure_openai.httpx.post", return_value=_resp(idx)),
+        patch("src.agents.ollama_client.httpx.post", return_value=_resp(idx)),
     ):
-        result = call_azure_for_action_index(
+        result = call_ollama_for_action_index(
             _FAKE_OBS, legal, model=_DEFAULT_MODEL, temperature=0.5, top_p=0.9
         )
     assert result == idx
@@ -308,13 +324,13 @@ def test_when_any_valid_temperature_given_then_it_appears_verbatim_in_body(tempe
 
     Invariant: no rounding, clamping, or transformation is applied.
     """
-    from src.agents.azure_openai import call_azure_for_action_index
+    from src.agents.ollama_client import call_ollama_for_action_index
 
     with (
         patch.dict("os.environ", _FAKE_ENV, clear=False),
-        patch("src.agents.azure_openai.httpx.post", return_value=_resp(0)) as mock_post,
+        patch("src.agents.ollama_client.httpx.post", return_value=_resp(0)) as mock_post,
     ):
-        call_azure_for_action_index(
+        call_ollama_for_action_index(
             _FAKE_OBS, ["a"], model=_DEFAULT_MODEL, temperature=temperature, top_p=None
         )
 

--- a/tests/test_player_config.py
+++ b/tests/test_player_config.py
@@ -29,14 +29,14 @@ class TestPlayerConfigFrozen:
         with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
             cfg.temperature = 0.5  # type: ignore[misc]
 
-    def test_when_model_omitted_defaults_to_gpt_4_1(self) -> None:
+    def test_when_model_omitted_defaults_to_gpt_oss_120b(self) -> None:
         cfg = PlayerConfig(
             player_id=0,
             temperature=0.1,
             top_p=0.9,
             strategy_hint="hint",
         )
-        assert cfg.model == "gpt-4.1"
+        assert cfg.model == "gpt-oss:120b"
         assert cfg.model == DEFAULT_MODEL
 
     def test_when_model_provided_stores_value(self) -> None:
@@ -127,8 +127,8 @@ class TestDefault6PProfiles:
         ids = [p.player_id for p in DEFAULT_6P_PROFILES]
         assert len(set(ids)) == len(ids)
 
-    def test_when_checking_all_models_default_to_gpt_4_1(self) -> None:
-        assert all(p.model == "gpt-4.1" for p in DEFAULT_6P_PROFILES)
+    def test_when_checking_all_models_default_to_gpt_oss_120b(self) -> None:
+        assert all(p.model == "gpt-oss:120b" for p in DEFAULT_6P_PROFILES)
 
 
 class TestLoadProfilesFromYaml:
@@ -156,7 +156,7 @@ class TestLoadProfilesFromYaml:
         assert profiles[0].player_id == 0
         assert profiles[0].temperature == pytest.approx(0.5)
 
-    def test_when_yaml_omits_model_field_defaults_to_gpt_4_1(self, tmp_path: Path) -> None:
+    def test_when_yaml_omits_model_field_defaults_to_gpt_oss_120b(self, tmp_path: Path) -> None:
         data = [
             {
                 "player_id": 0,
@@ -168,7 +168,7 @@ class TestLoadProfilesFromYaml:
         path = tmp_path / "profiles.yaml"
         path.write_text(yaml.dump(data))
         profiles = load_profiles_from_yaml(path)
-        assert profiles[0].model == "gpt-4.1"
+        assert profiles[0].model == "gpt-oss:120b"
 
     def test_when_yaml_has_duplicate_player_ids_raises_value_error(self, tmp_path: Path) -> None:
         data = [

--- a/tests/test_player_config.py
+++ b/tests/test_player_config.py
@@ -135,7 +135,7 @@ class TestLoadProfilesFromYaml:
     """YAML loader validation and error handling."""
 
     def test_when_loading_default_yaml_round_trips_to_six_profiles(self) -> None:
-        yaml_path = Path("/Volumes/External SSD/risiko/config/default_6p.yaml")
+        yaml_path = Path(__file__).resolve().parents[1] / "config" / "default_6p.yaml"
         profiles = load_profiles_from_yaml(yaml_path)
         assert profiles == list(DEFAULT_6P_PROFILES)
 

--- a/tests/test_player_profiles_default.py
+++ b/tests/test_player_profiles_default.py
@@ -2,13 +2,13 @@
 
 Criteria covered:
   [UNIT] PlayerConfig is a frozen dataclass with player_id, temperature,
-         top_p, strategy_hint, model (default "gpt-4.1")
+         top_p, strategy_hint, model (default "gpt-oss:120b")
   [UNIT] DEFAULT_6P_PROFILES matches the six-profile table exactly
   [UNIT] load_profiles_from_yaml() round-trips config/default_6p.yaml;
          raises ValueError on out-of-range (player_id not in 0–5) or
          duplicate player_id
   [UNIT] config/default_6p.yaml and config/llm_6p.yaml parse cleanly and
-         contain only Azure-relevant keys (no Ollama/BAML residue)
+         contain no BAML residue
 """
 
 from __future__ import annotations
@@ -57,21 +57,21 @@ def _write_profiles_yaml(profiles: list[PlayerConfig], path: str | pathlib.Path)
 class TestPlayerConfigDataclass:
     """Frozen dataclass contract for PlayerConfig."""
 
-    def test_when_model_omitted_then_default_is_gpt_41(self):
-        """Criterion: model field defaults to 'gpt-4.1'."""
+    def test_when_model_omitted_then_default_is_gpt_oss_120b(self):
+        """Criterion: model field defaults to 'gpt-oss:120b'."""
         pc = PlayerConfig(player_id=0, temperature=0.5, top_p=0.9, strategy_hint="hint")
-        assert pc.model == "gpt-4.1"
+        assert pc.model == "gpt-oss:120b"
 
     def test_when_all_fields_supplied_then_fields_are_stored_correctly(self):
         """Criterion: PlayerConfig has player_id, temperature, top_p, strategy_hint, model."""
         pc = PlayerConfig(
-            player_id=3, temperature=0.3, top_p=0.95, strategy_hint="defend", model="gpt-4.1"
+            player_id=3, temperature=0.3, top_p=0.95, strategy_hint="defend", model="gpt-oss:120b"
         )
         assert pc.player_id == 3
         assert pc.temperature == pytest.approx(0.3)
         assert pc.top_p == pytest.approx(0.95)
         assert pc.strategy_hint == "defend"
-        assert pc.model == "gpt-4.1"
+        assert pc.model == "gpt-oss:120b"
 
     def test_when_attribute_mutated_then_frozen_error_is_raised(self):
         """Criterion: PlayerConfig is frozen (immutable after construction)."""
@@ -136,11 +136,11 @@ class TestDefault6PProfiles:
         )
         assert profile.strategy_hint == strategy_hint, f"player {player_id}: strategy_hint mismatch"
 
-    def test_when_all_default_models_checked_then_every_profile_uses_gpt_41(self):
-        """Criterion: default model for all profiles is 'gpt-4.1'."""
+    def test_when_all_default_models_checked_then_every_profile_uses_gpt_oss_120b(self):
+        """Criterion: default model for all profiles is 'gpt-oss:120b'."""
         for profile in DEFAULT_6P_PROFILES:
-            assert profile.model == "gpt-4.1", (
-                f"player {profile.player_id} has model={profile.model!r}, expected 'gpt-4.1'"
+            assert profile.model == "gpt-oss:120b", (
+                f"player {profile.player_id} has model={profile.model!r}, expected 'gpt-oss:120b'"
             )
 
     def test_when_default_profiles_checked_then_no_duplicate_player_ids_exist(self):
@@ -176,7 +176,7 @@ class TestLoadProfilesFromYaml:
                 "temperature": 0.7,
                 "top_p": 0.85,
                 "strategy_hint": "attack early",
-                "model": "gpt-4.1",
+                "model": "gpt-oss:120b",
             }
         ]
         path = tmp_path / "profiles.yaml"
@@ -287,15 +287,13 @@ def test_when_profiles_written_to_yaml_and_loaded_back_then_field_values_are_pre
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# YAML config files: must parse and contain no Ollama / BAML residue
+# YAML config files: must parse and contain no BAML residue
 #
 # Criterion: config/default_6p.yaml and config/llm_6p.yaml parse cleanly
-#            and contain only Azure-relevant keys.
+#            and contain no stray BAML keys.
 # ────────────────────────────────────────────────────────────────────────────
 
-_FORBIDDEN_KEYS: frozenset[str] = frozenset(
-    {"ollama", "baml", "baml_src", "baml_client", "baml_options", "ollama_model"}
-)
+_FORBIDDEN_KEYS: frozenset[str] = frozenset({"baml", "baml_src", "baml_client", "baml_options"})
 
 
 def _collect_all_keys(obj: object) -> set[str]:
@@ -311,8 +309,8 @@ def _collect_all_keys(obj: object) -> set[str]:
     return keys
 
 
-class TestYamlConfigFilesAzureOnly:
-    """YAML config files must parse cleanly and contain only Azure-relevant keys."""
+class TestYamlConfigFilesClean:
+    """YAML config files must parse cleanly and contain no stray BAML keys."""
 
     def test_when_default_6p_yaml_opened_then_it_parses_without_error(self):
         """Criterion: config/default_6p.yaml parses cleanly."""
@@ -321,16 +319,16 @@ class TestYamlConfigFilesAzureOnly:
             data = yaml.safe_load(fh)
         assert data is not None, "default_6p.yaml must not be empty"
 
-    def test_when_default_6p_yaml_keys_inspected_then_no_ollama_or_baml_key_present(self):
-        """Criterion: no Ollama/BAML residue in default_6p.yaml."""
+    def test_when_default_6p_yaml_keys_inspected_then_no_baml_key_present(self):
+        """Criterion: no BAML residue in default_6p.yaml."""
         yaml_path = PROJECT_ROOT / "config" / "default_6p.yaml"
         with open(yaml_path) as fh:
             data = yaml.safe_load(fh)
         found = _collect_all_keys(data) & _FORBIDDEN_KEYS
-        assert not found, f"Forbidden (Ollama/BAML) keys found in default_6p.yaml: {found}"
+        assert not found, f"Forbidden (BAML) keys found in default_6p.yaml: {found}"
 
     def test_when_llm_6p_yaml_exists_then_it_is_at_expected_path(self):
-        """Criterion: config/llm_6p.yaml exists (Azure pool config)."""
+        """Criterion: config/llm_6p.yaml exists (Ollama pool config)."""
         assert (PROJECT_ROOT / "config" / "llm_6p.yaml").exists(), "config/llm_6p.yaml must exist"
 
     def test_when_llm_6p_yaml_opened_then_it_parses_without_error(self):
@@ -341,11 +339,11 @@ class TestYamlConfigFilesAzureOnly:
             data = yaml.safe_load(fh)
         assert data is not None, "llm_6p.yaml must not be empty"
 
-    def test_when_llm_6p_yaml_keys_inspected_then_no_ollama_or_baml_key_present(self):
-        """Criterion: no Ollama/BAML residue in llm_6p.yaml."""
+    def test_when_llm_6p_yaml_keys_inspected_then_no_baml_key_present(self):
+        """Criterion: no BAML residue in llm_6p.yaml."""
         yaml_path = PROJECT_ROOT / "config" / "llm_6p.yaml"
         assert yaml_path.exists(), "config/llm_6p.yaml must exist"
         with open(yaml_path) as fh:
             data = yaml.safe_load(fh)
         found = _collect_all_keys(data) & _FORBIDDEN_KEYS
-        assert not found, f"Forbidden (Ollama/BAML) keys found in llm_6p.yaml: {found}"
+        assert not found, f"Forbidden (BAML) keys found in llm_6p.yaml: {found}"

--- a/tests/test_self_play_smoke.py
+++ b/tests/test_self_play_smoke.py
@@ -5,7 +5,7 @@ Covers:
 - GAE on compute_advantages(): buffer stores transitions, advantages are computed
 - NaN log_prob transitions: skipped by SelfPlayTrainer._buffer_learner_transitions()
 - Checkpoint resumability: episode counter, RNG state, opponent round-trip
-- LLM pool wiring: N-1 LLMOpponents built from profiles YAML (Azure mocked)
+- LLM pool wiring: N-1 LLMOpponents built from profiles YAML (Ollama mocked)
 
 All tests use tiny sizes and seed=0 for speed.
 """
@@ -72,7 +72,7 @@ def _minimal_action() -> dict:
     return {k: torch.tensor(0) for k in ("action_type", "param_a", "param_b", "param_c", "param_d")}
 
 
-def _fake_azure_response(index: int = 0) -> MagicMock:
+def _fake_ollama_response(index: int = 0) -> MagicMock:
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {
@@ -89,7 +89,7 @@ def _write_player_profiles(path: pathlib.Path, n: int) -> None:
             "temperature": 0.1,
             "top_p": 0.9,
             "strategy_hint": "play optimally",
-            "model": "gpt-4.1",
+            "model": "gpt-oss:120b",
         }
         for i in range(n)
     ]
@@ -395,17 +395,14 @@ class TestLlmPoolWiring:
         profiles = tmp_path / "profiles.yaml"
         _write_player_profiles(profiles, 2)
 
-        monkeypatch.setenv(
-            "AZURE_OPENAI_BASE_URL", "https://fake.azure.com/openai/deployments/gpt-4.1"
-        )
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
 
         cfg = TrainingConfig(
             seed=0,
             self_play=SelfPlayConfig(n_players=3, llm_profiles_path=str(profiles)),
         )
-        with patch("httpx.post", return_value=_fake_azure_response(0)):
+        with patch("httpx.post", return_value=_fake_ollama_response(0)):
             trainer = SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, max_turns=10)
 
         assert trainer._llm_opponents is not None
@@ -419,17 +416,14 @@ class TestLlmPoolWiring:
         profiles = tmp_path / "profiles.yaml"
         _write_player_profiles(profiles, 3)
 
-        monkeypatch.setenv(
-            "AZURE_OPENAI_BASE_URL", "https://fake.azure.com/openai/deployments/gpt-4.1"
-        )
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
 
         cfg = TrainingConfig(
             seed=0,
             self_play=SelfPlayConfig(n_players=4, llm_profiles_path=str(profiles)),
         )
-        with patch("httpx.post", return_value=_fake_azure_response(0)):
+        with patch("httpx.post", return_value=_fake_ollama_response(0)):
             trainer = SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, max_turns=10)
 
         assert trainer._llm_opponents is not None
@@ -437,17 +431,14 @@ class TestLlmPoolWiring:
         assert all(isinstance(o, LLMOpponent) for o in trainer._llm_opponents)
 
     def test_no_http_call_on_trainer_construction(self, tmp_path, monkeypatch) -> None:
-        """LLMOpponent construction must not make any Azure HTTP requests."""
+        """LLMOpponent construction must not make any Ollama HTTP requests."""
         from training.self_play import SelfPlayTrainer
 
         profiles = tmp_path / "profiles.yaml"
         _write_player_profiles(profiles, 1)
 
-        monkeypatch.setenv(
-            "AZURE_OPENAI_BASE_URL", "https://fake.azure.com/openai/deployments/gpt-4.1"
-        )
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
-        monkeypatch.setenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama")
 
         cfg = TrainingConfig(
             seed=0,
@@ -458,7 +449,7 @@ class TestLlmPoolWiring:
 
         def _counting(*a: Any, **kw: Any) -> MagicMock:
             calls.append(1)
-            return _fake_azure_response(0)
+            return _fake_ollama_response(0)
 
         with patch("httpx.post", side_effect=_counting):
             SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, max_turns=10)

--- a/tests/test_utils_env.py
+++ b/tests/test_utils_env.py
@@ -5,9 +5,8 @@ All dotenv I/O is mocked; no real .env file is read.
 
 Criteria covered:
 - ensure_env_loaded() is idempotent: calling it N times invokes load_dotenv exactly once
-- When python-dotenv is not installed the function raises ImportError
+- When python-dotenv is not installed the function returns gracefully (no raise)
 - Happy path calls load_dotenv(find_dotenv(usecwd=True))
-- Raises AzureConfigError when AZURE_OPENAI_BASE_URL or AZURE_OPENAI_API_KEY is unresolved
 """
 
 from __future__ import annotations
@@ -51,7 +50,7 @@ def test_when_called_twice_then_load_dotenv_is_invoked_exactly_once():
         patch("dotenv.load_dotenv", mock_load),
         patch.dict(
             "os.environ",
-            {"AZURE_OPENAI_BASE_URL": "https://x", "AZURE_OPENAI_API_KEY": "k"},
+            {"OLLAMA_BASE_URL": "http://localhost:11434/v1", "OLLAMA_API_KEY": "ollama"},
             clear=False,
         ),
     ):
@@ -99,7 +98,7 @@ def test_when_dotenv_present_then_find_dotenv_is_called_with_usecwd_true():
         patch("dotenv.load_dotenv", mock_load),
         patch.dict(
             "os.environ",
-            {"AZURE_OPENAI_BASE_URL": "https://x", "AZURE_OPENAI_API_KEY": "k"},
+            {"OLLAMA_BASE_URL": "http://localhost:11434/v1", "OLLAMA_API_KEY": "ollama"},
             clear=False,
         ),
     ):
@@ -124,7 +123,7 @@ def test_when_dotenv_present_then_load_dotenv_is_called_with_path_from_find_dote
         patch("dotenv.load_dotenv", mock_load),
         patch.dict(
             "os.environ",
-            {"AZURE_OPENAI_BASE_URL": "https://x", "AZURE_OPENAI_API_KEY": "k"},
+            {"OLLAMA_BASE_URL": "http://localhost:11434/v1", "OLLAMA_API_KEY": "ollama"},
             clear=False,
         ),
     ):
@@ -145,7 +144,7 @@ def test_when_dotenv_present_then_load_dotenv_is_called_with_path_from_find_dote
 def test_when_called_n_times_then_load_dotenv_is_always_called_exactly_once(
     n_calls: int,
 ) -> None:
-    """ensure_env_loaded() is idempotent for any number of calls ≥ 1.
+    """ensure_env_loaded() is idempotent for any number of calls >= 1.
 
     Invariant: the dotenv load side-effect occurs exactly once, regardless
     of how many times the caller invokes ensure_env_loaded().
@@ -160,7 +159,7 @@ def test_when_called_n_times_then_load_dotenv_is_always_called_exactly_once(
         patch("dotenv.load_dotenv", mock_load),
         patch.dict(
             "os.environ",
-            {"AZURE_OPENAI_BASE_URL": "https://x", "AZURE_OPENAI_API_KEY": "k"},
+            {"OLLAMA_BASE_URL": "http://localhost:11434/v1", "OLLAMA_API_KEY": "ollama"},
             clear=False,
         ),
     ):


### PR DESCRIPTION
## Why
Azure OpenAI cost money and locked the project to a vendor. Switch the LLM opponent back to **Ollama** so anyone can run it **locally for free**, while training can still use a hosted big model (`gpt-oss:120b`) via **Ollama Cloud**. The `env_core` modularization from the previous commit is preserved — this is a forward un-migration, not a `git revert`.

## What
- **NEW** `src/agents/ollama_client.py` — `call_ollama_for_action_index()`, OpenAI-compatible `/v1/chat/completions`, `Authorization: Bearer`, `response_format` json_schema strict index output. Never hard-fails on missing key (local needs none).
- **REMOVED** `src/agents/azure_openai.py`
- One client, two modes — differ only by `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` / model:
  - Local (free): `http://localhost:11434/v1`, no key, e.g. `gpt-oss:20b`
  - Cloud: `https://ollama.com/v1` + key, `gpt-oss:120b`
- Default model → `gpt-oss:120b`; dropped `api_version`
- Migrated 16 test files; renamed `test_azure_*` → `test_ollama_*`
- Added `hypothesis` (dev) + `python-dotenv` (runtime) to `pyproject` so CI installs them
- Updated `README.md` and `CLAUDE.md`

## Tests
- Full suite: **1394 passed, 2 skipped** (pre-existing skips)
- `ruff check . tests`: clean
- Coverage on `src/`: **98%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)