### PR TITLE
fix(ollama): tolerant action_index parsing + larger reasoning token budget

### DIFF
--- a/scripts/try_ollama_opponent.py
+++ b/scripts/try_ollama_opponent.py
@@ -1,0 +1,52 @@
+"""One-shot manual check: real Ollama LLM opponent picks a legal action.
+
+Local model: a single inference only (laptop RAM-friendly).
+Cloud model: routed through the Ollama daemon to ollama.com (no local RAM).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+
+from src.agents.llm_opponent import LLMOpponent
+from src.agents.ollama_client import call_ollama_for_action_index
+from src.env import RisikoEnv
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+
+def main() -> int:
+    """Run one real Ollama action selection and print the chosen move."""
+    env = RisikoEnv(n_players=3)
+    obs, info = env.reset(seed=42)
+    legal = info["legal_actions"]
+    print(f"\nlegal_actions: {len(legal)} options; first 3: {legal[:3]}\n")
+
+    label = sys.argv[1] if len(sys.argv) > 1 else "local"
+    model = sys.argv[2] if len(sys.argv) > 2 else "gemma4:12b-mlx"
+    max_tokens = int(sys.argv[3]) if len(sys.argv) > 3 else 8192
+
+    print(f"=== {label.upper()} — model={model} max_tokens={max_tokens} ===")
+    t0 = time.time()
+    idx = call_ollama_for_action_index(
+        obs, legal, model=model, timeout=180.0, temperature=0.1, max_tokens=max_tokens
+    )
+    dt = time.time() - t0
+    if idx is None:
+        print(f"RESULT: no usable index ({dt:.1f}s) -> opponent falls back to random")
+        return 1
+    print(f"RESULT: real LLM chose idx={idx} -> {legal[idx]}  ({dt:.1f}s)")
+
+    # Local: stop here (one inference only, RAM-friendly).
+    # Cloud: also exercise the full agent wrapper (no local RAM cost).
+    if label == "cloud":
+        agent = LLMOpponent(model=model, timeout=120.0)
+        action = agent.act(obs, legal)
+        print(f"LLMOpponent.act() -> {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 from typing import Any
 
@@ -45,7 +46,7 @@ ENV_API_KEY = "OLLAMA_API_KEY"
 
 DEFAULT_BASE_URL = "http://localhost:11434/v1"
 DEFAULT_API_KEY = "ollama"  # placeholder; Ollama ignores it for local serving
-DEFAULT_MAX_TOKENS = 512  # leaves headroom for gpt-oss reasoning before the JSON answer
+DEFAULT_MAX_TOKENS = 4096  # reasoning models (gpt-oss, glm) think before the JSON; leave room
 
 _RESPONSE_FORMAT: dict[str, Any] = {
     "type": "json_schema",
@@ -133,6 +134,30 @@ def call_ollama_for_action_index(
     return _parse_index(data, legal_actions, model, elapsed)
 
 
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+_INDEX_RE = re.compile(r'"?action_index"?\s*[:=]\s*(-?\d+)')
+
+
+def _extract_action_index(content: str) -> int | None:
+    """Pull an integer ``action_index`` out of a model reply, tolerantly.
+
+    Not all Ollama models honour ``response_format`` json_schema; reasoning
+    models in particular wrap the answer in a ```json fence or add prose. Try
+    strict JSON first, then a fenced-JSON unwrap, then a regex fallback.
+    """
+    candidates = [content.strip()]
+    fenced = _FENCE_RE.search(content)
+    if fenced:
+        candidates.append(fenced.group(1).strip())
+    for candidate in candidates:
+        try:
+            return int(json.loads(candidate)["action_index"])
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+            continue
+    match = _INDEX_RE.search(content)
+    return int(match.group(1)) if match else None
+
+
 def _parse_index(
     data: dict[str, Any],
     legal_actions: list[dict[str, int]],
@@ -147,10 +172,9 @@ def _parse_index(
     if not content:
         _log.warning("Ollama returned empty content (model=%s, %.2fs)", model, elapsed)
         return None
-    try:
-        idx = int(json.loads(content)["action_index"])
-    except (json.JSONDecodeError, KeyError, ValueError, TypeError) as e:
-        _log.warning("Ollama reply not parseable as {action_index: int}: %s | raw=%r", e, content)
+    idx = _extract_action_index(content)
+    if idx is None:
+        _log.warning("Ollama reply has no usable action_index | raw=%r", content)
         return None
     if 0 <= idx < len(legal_actions):
         _log.info(

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -336,3 +336,75 @@ def test_when_any_valid_temperature_given_then_it_appears_verbatim_in_body(tempe
 
     body = mock_post.call_args.kwargs.get("json", {})
     assert body.get("temperature") == pytest.approx(temperature, rel=1e-6, abs=1e-9)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tolerant parsing: not every model honours response_format json_schema.
+# Reasoning/instruct models may wrap the answer in a ```json fence or add prose;
+# _extract_action_index must still recover a usable action_index.
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractActionIndex:
+    """Direct unit tests for the tolerant action_index extractor."""
+
+    def test_when_strict_json_then_index_is_extracted(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index('{"action_index": 7}') == 7
+
+    def test_when_json_fenced_with_lang_tag_then_index_is_extracted(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index('```json\n{"action_index": 51}\n```') == 51
+
+    def test_when_json_fenced_without_lang_tag_then_index_is_extracted(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index('```\n{"action_index": 3}\n```') == 3
+
+    def test_when_prose_surrounds_json_then_regex_fallback_extracts_index(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index("I choose action_index: 12 because it is best.") == 12
+
+    def test_when_extra_keys_present_then_index_is_still_extracted(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index('{"reason": "expand", "action_index": 4}') == 4
+
+    def test_when_no_index_anywhere_then_returns_none(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index("sorry, I cannot decide") is None
+
+    def test_when_empty_string_then_returns_none(self):
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index("") is None
+
+
+class TestTolerantParsingThroughClient:
+    """The client recovers fenced/prose replies into a legal in-range index."""
+
+    def test_when_reply_is_fenced_json_then_client_returns_in_range_index(self):
+        legal = ["a", "b", "c"]
+        result, _ = _call(legal, resp=_fake_response('```json\n{"action_index": 2}\n```'))
+        assert result == 2
+
+    def test_when_fenced_index_out_of_range_then_client_returns_none(self):
+        legal = ["a", "b"]
+        result, _ = _call(legal, resp=_fake_response('```json\n{"action_index": 9}\n```'))
+        assert result is None
+
+    def test_when_reply_has_prose_then_client_recovers_index(self):
+        legal = ["a", "b", "c", "d"]
+        result, _ = _call(legal, resp=_fake_response("Best move is action_index = 3."))
+        assert result == 3
+
+
+def test_default_max_tokens_leaves_reasoning_headroom():
+    """Default token budget must be large enough for reasoning models to answer."""
+    from src.agents.ollama_client import DEFAULT_MAX_TOKENS
+
+    assert DEFAULT_MAX_TOKENS >= 2048


### PR DESCRIPTION
## Why
Live-testing the LLM opponent against real Ollama models (local + cloud) surfaced two bugs that forced unnecessary `RandomAgent` fallbacks.

## Findings (from real runs)
- **`glm-5.1:cloud`** returned a valid but **fenced** answer — ```` ```json\n{"action_index": 51}\n``` ```` — which the strict `json.loads` rejected. Many models ignore `response_format` json_schema.
- **Reasoning models** spend completion tokens thinking before the answer, so the **512-token** default truncated the reply to empty content → fallback.

## Fix
- `_extract_action_index`: strict JSON → fenced-JSON unwrap → regex fallback (`action_index: N`).
- `DEFAULT_MAX_TOKENS` 512 → **4096**.

## Tests
- Unit tests for the extractor: strict / fenced (with & without lang tag) / prose / extra-keys / garbage / empty / out-of-range.
- Client-level tests proving fenced & prose replies recover to an in-range index.
- Full suite: **1405 passed, 2 (pre-existing) skips**; ruff clean.

## Verified end-to-end
`qwen3-coder-next:cloud` → `LLMOpponent.act()` returns a **legal** move in **~0.7s**, no fallback.

## Notes
- Reasoning models (glm-5.1) remain flaky for this tiny-answer task (reasoning sometimes truncates). Prefer **instruct** models. For `gpt-oss:120b`, wiring `think:false` / `reasoning_effort:low` is a sensible follow-up (not in this PR).
- Adds `scripts/try_ollama_opponent.py` — manual smoke helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)