### PR TITLE
fix(security): safe checkpoint deserialization (weights_only=True + allowlist)

### DIFF
--- a/risiko_rl/agent_loader.py
+++ b/risiko_rl/agent_loader.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import torch
-
 from src.agents.llm_opponent import LLMOpponent
 from src.agents.player_config import load_profiles_from_yaml
 from src.agents.ppo_agent import PPOAgent
@@ -14,6 +12,7 @@ from src.agents.random_agent import RandomAgent
 from src.models.actor_critic import ActorCritic
 from src.models.utils import get_obs_dim
 from src.utils.constants import ACTION_DIMS
+from src.utils.safe_torch import safe_torch_load
 
 
 def load_agent(spec: str, *, seed: int | None = None) -> Any:
@@ -42,7 +41,7 @@ def load_agent(spec: str, *, seed: int | None = None) -> Any:
     if not path.exists():
         raise FileNotFoundError(f"Checkpoint not found: {spec}")
 
-    checkpoint = torch.load(path, weights_only=False)
+    checkpoint = safe_torch_load(path)
     config = checkpoint.get("config", {})
     network_cfg = config.get("network", {})
     hidden_sizes = network_cfg.get("hidden_sizes", (256, 256))

--- a/src/checkpoint.py
+++ b/src/checkpoint.py
@@ -11,6 +11,7 @@ import torch
 from src.config import PPOConfig, TrainingConfig
 from src.env import RisikoEnv
 from src.models.ppo import PPOTrainer
+from src.utils.safe_torch import safe_torch_load
 
 
 def _config_to_dict(config: TrainingConfig) -> dict[str, Any]:
@@ -69,7 +70,7 @@ def load_checkpoint(path: str | Path) -> dict[str, Any]:
     Returns a dict with keys ``config``, ``model_state_dict``,
     ``optimizer_state_dict``.
     """
-    payload = torch.load(Path(path), weights_only=False)
+    payload = safe_torch_load(Path(path))
     payload["config"] = _config_from_dict(payload["config"])
     return payload
 
@@ -115,6 +116,6 @@ class CheckpointManager:
         Returns:
             Dict with keys: trainer_state, rng_state, episode, config.
         """
-        payload = torch.load(path, weights_only=False)
+        payload = safe_torch_load(path)
         payload["config"] = _config_from_dict(payload["config"])
         return payload

--- a/src/utils/safe_torch.py
+++ b/src/utils/safe_torch.py
@@ -1,0 +1,68 @@
+"""Hardened ``torch.load`` that refuses arbitrary code execution.
+
+``torch.load(..., weights_only=False)`` unpickles arbitrary Python objects, so a
+malicious ``.pt`` file can run code on load (pickle ``__reduce__`` -> RCE). We
+instead load with ``weights_only=True`` — which executes no code — and explicitly
+allowlist only the benign types our own checkpoints legitimately contain (the
+frozen config dataclasses and the numpy RNG state). An attacker therefore cannot
+smuggle a dangerous global past the allowlist, while genuine checkpoints (and
+resume) keep working.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import torch
+
+_REGISTERED = False
+
+
+def _config_safe_globals() -> list[Any]:
+    """Project config dataclasses stored inside checkpoints."""
+    from src.config import NetworkConfig, PPOConfig, SelfPlayConfig, TrainingConfig
+    from src.utils.reward_config import RewardConfig
+
+    return [TrainingConfig, PPOConfig, NetworkConfig, SelfPlayConfig, RewardConfig]
+
+
+def _numpy_safe_globals() -> list[Any]:
+    """Globals needed to unpickle ``np.random.get_state()`` (an ndarray of uint32)."""
+    import numpy as np
+
+    allow: list[Any] = [np.ndarray, np.dtype]
+    core = getattr(np, "_core", None) or getattr(np, "core", None)
+    reconstruct = getattr(getattr(core, "multiarray", None), "_reconstruct", None)
+    if reconstruct is not None:
+        allow.append(reconstruct)
+    dtypes_mod = getattr(np, "dtypes", None)
+    if dtypes_mod is not None:
+        for name in ("UInt32DType", "Int64DType", "Float64DType"):
+            klass = getattr(dtypes_mod, name, None)
+            if klass is not None:
+                allow.append(klass)
+    return allow
+
+
+def _ensure_registered() -> None:
+    """Register the allowlist with torch exactly once (process-wide, idempotent)."""
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    torch.serialization.add_safe_globals(_config_safe_globals() + _numpy_safe_globals())
+    _REGISTERED = True
+
+
+def safe_torch_load(path: str | Path) -> Any:
+    """Load a checkpoint safely: ``weights_only=True`` plus a benign-type allowlist.
+
+    Raises:
+        pickle.UnpicklingError: If the file references any global outside the
+            allowlist (e.g. a malicious payload attempting code execution).
+    """
+    _ensure_registered()
+    return torch.load(Path(path), weights_only=True)
+
+
+__all__ = ["safe_torch_load"]

--- a/tests/test_safe_torch.py
+++ b/tests/test_safe_torch.py
@@ -1,0 +1,78 @@
+"""Tests for the hardened checkpoint loader (src.utils.safe_torch).
+
+Covers both halves of the contract:
+- A malicious checkpoint (pickle reduce -> arbitrary callable) is rejected, not
+  executed — the whole point of weights_only=True.
+- A genuine checkpoint containing numpy RNG state and a config dataclass still
+  loads, so resume keeps working.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import random
+
+import numpy as np
+import pytest
+import torch
+
+from src.config import PPOConfig, TrainingConfig
+from src.utils.safe_torch import safe_torch_load
+
+
+class _ReduceToCallable:
+    """Pickles into a call of an un-allowlisted global (simulates an RCE payload)."""
+
+    def __reduce__(self):
+        # os.getcwd is harmless if it ever ran; weights_only must still REFUSE it.
+        return (os.getcwd, ())
+
+
+def test_when_checkpoint_references_unlisted_global_then_load_is_refused(tmp_path):
+    evil = tmp_path / "evil.pt"
+    torch.save({"payload": _ReduceToCallable()}, evil)
+
+    with pytest.raises(pickle.UnpicklingError):
+        safe_torch_load(evil)
+
+
+def test_when_checkpoint_has_numpy_rng_and_config_then_load_succeeds(tmp_path):
+    np.random.seed(7)
+    random.seed(7)
+    torch.manual_seed(7)
+    payload = {
+        "trainer_state": {
+            "model": {"w": torch.randn(2, 2)},
+            "optimizer": {"step": 1},
+            "config": PPOConfig(lr=0.001),  # dataclass embedded by PPOTrainer.save_checkpoint
+        },
+        "rng_state": {
+            "torch": torch.get_rng_state(),
+            "numpy": np.random.get_state(),  # contains a uint32 ndarray
+            "random": random.getstate(),
+            "env": {"bit_generator": "PCG64", "state": {"state": 1, "inc": 3}},
+        },
+        "episode": 42,
+        "config": {"seed": 42, "ppo": {"lr": 0.001}},
+    }
+    path = tmp_path / "good.pt"
+    torch.save(payload, path)
+
+    loaded = safe_torch_load(path)
+
+    assert loaded["episode"] == 42
+    assert isinstance(loaded["trainer_state"]["config"], PPOConfig)
+    assert loaded["rng_state"]["numpy"][0] == "MT19937"
+    assert isinstance(loaded["rng_state"]["numpy"][1], np.ndarray)
+
+
+def test_when_config_dataclass_round_trips_then_values_match(tmp_path):
+    cfg = TrainingConfig(total_timesteps=1234, ppo=PPOConfig(lr=0.002))
+    path = tmp_path / "cfg.pt"
+    torch.save({"config": cfg}, path)
+
+    loaded = safe_torch_load(path)
+
+    assert loaded["config"].total_timesteps == 1234
+    assert loaded["config"].ppo.lr == pytest.approx(0.002)


### PR DESCRIPTION
## Why
`torch.load(..., weights_only=False)` unpickles arbitrary objects — a malicious `.pt` can run code on load (pickle `__reduce__` → RCE). Three load sites were affected:
- `src/checkpoint.py` → `load_checkpoint`
- `src/checkpoint.py` → `CheckpointManager.load`
- `risiko_rl/agent_loader.py` → `load_agent`

## Why not just flip the flag (cf. #55)
PR #55 set `weights_only=True` on only one of the three sites — and it **breaks resume**. Our checkpoints legitimately store `np.random.get_state()` (a uint32 ndarray) and a `PPOConfig` dataclass; `weights_only=True` rejects both. Verified on torch 2.11: applying #55's change makes **7 checkpoint tests fail** with `UnpicklingError (… PPOConfig was not an allowed global)`.

## Fix
New `src/utils/safe_torch.py` → `safe_torch_load()`:
- loads with `weights_only=True` (no code execution), **and**
- registers an explicit allowlist of exactly the benign types our checkpoints contain — the config dataclasses + the numpy RNG globals — via `torch.serialization.add_safe_globals`.

So an attacker cannot smuggle a dangerous global past the allowlist, while genuine checkpoints and deterministic resume keep working. All three sites route through it.

## Tests (`tests/test_safe_torch.py`)
- malicious `__reduce__` payload → **refused** with `UnpicklingError` (not executed)
- real checkpoint with numpy RNG state + `PPOConfig` → loads, values intact
- config dataclass round-trips

Full suite: **1408 passed, 2 (pre-existing) skips**; ruff + format clean.

Supersedes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)