### PR TITLE
feat(train): add --model flag with Ollama pre-flight check

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Win rates at 6 players (random baseline ≈ 1/6 ≈ 16.7%):
 
 ## Six-player LLM profiles
 
-Defined in `config/default_6p.yaml`. Each slot uses `gpt-oss:120b` (override per slot via the `model` field) with a distinct `temperature`/`top_p` and a strategy hint injected into the prompt.
+Defined in `config/default_6p.yaml`. Each slot defaults to `gemma4:12b-mlx` (local, free) with a distinct `temperature`/`top_p` and a strategy hint injected into the prompt. Override the model **per slot** via the `model` field, or **uniformly for all slots** at launch with `risiko-rl train --model <name>` (e.g. `--model glm-5.1:cloud`). The requested model is pre-flight checked against the Ollama server's model list, so a typo fails fast instead of silently degrading every opponent to random.
 
 | Player | Temp | Top-p | Strategy hint |
 |---|---|---|---|

--- a/config/default_6p.yaml
+++ b/config/default_6p.yaml
@@ -2,34 +2,34 @@
   temperature: 0.1
   top_p: 0.9
   strategy_hint: "Play greedily: maximise territory gain each turn."
-  model: gpt-oss:120b
+  model: gemma4:12b-mlx
 
 - player_id: 1
   temperature: 0.4
   top_p: 0.9
   strategy_hint: "Focus on securing full continents before expanding."
-  model: gpt-oss:120b
+  model: gemma4:12b-mlx
 
 - player_id: 2
   temperature: 0.7
   top_p: 0.85
   strategy_hint: "Eliminate the weakest player early; control cards."
-  model: gpt-oss:120b
+  model: gemma4:12b-mlx
 
 - player_id: 3
   temperature: 0.3
   top_p: 0.95
   strategy_hint: "Fortify borders and expand only when safe."
-  model: gpt-oss:120b
+  model: gemma4:12b-mlx
 
 - player_id: 4
   temperature: 0.9
   top_p: 0.8
   strategy_hint: "Play unpredictably; avoid predictable attack patterns."
-  model: gpt-oss:120b
+  model: gemma4:12b-mlx
 
 - player_id: 5
   temperature: 0.5
   top_p: 0.9
   strategy_hint: "Balance attack and defence; trade cards conservatively."
-  model: gpt-oss:120b
+  model: gemma4:12b-mlx

--- a/risiko_rl/cli.py
+++ b/risiko_rl/cli.py
@@ -14,7 +14,7 @@ _project_root = Path(__file__).parent.parent.resolve()
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from src.config import load_config, merge_cli_overrides  # noqa: E402
+from src.config import TrainingConfig, load_config, merge_cli_overrides  # noqa: E402
 from src.utils.env import ensure_env_loaded  # noqa: E402
 from src.utils.log import setup_logging  # noqa: E402
 
@@ -23,6 +23,41 @@ from .agent_loader import load_agent  # noqa: E402, I001
 ensure_env_loaded()
 
 app = typer.Typer(help="Risiko RL — train and evaluate PPO agents")
+
+
+def _preflight_validate_model(cfg: TrainingConfig) -> None:
+    """Fail fast if an LLM opponent model is not available on the Ollama server.
+
+    Only runs in LLM mode (``self_play.llm_profiles_path`` set). Resolves the
+    effective model set — the ``--model`` override if given, else the distinct
+    models declared in the profile YAML — and checks each against the live
+    model list. If the server can't be queried, logs a warning and proceeds
+    (cloud ``/v1/models`` may differ); only a definitively-missing model aborts.
+    """
+    from src.agents.ollama_client import list_ollama_models
+    from src.agents.player_config import load_profiles_from_yaml
+
+    profiles_path = cfg.self_play.llm_profiles_path
+    if not profiles_path:
+        return
+
+    if cfg.self_play.llm_model:
+        wanted = {cfg.self_play.llm_model}
+    else:
+        wanted = {p.model for p in load_profiles_from_yaml(profiles_path)}
+
+    available = list_ollama_models()
+    if available is None:
+        typer.echo("Warning: could not query Ollama model list; skipping model pre-flight check.")
+        return
+
+    missing = sorted(wanted - available)
+    if missing:
+        raise typer.BadParameter(
+            f"Model(s) not available on Ollama server: {', '.join(missing)}. "
+            f"Available: {', '.join(sorted(available))}. "
+            "Pull the model (`ollama pull <name>`) or pass a valid --model."
+        )
 
 
 @app.command()
@@ -59,6 +94,14 @@ def train(
         int | None,
         typer.Option("--timesteps", help="Total training timesteps (overrides config)"),
     ] = None,
+    model: Annotated[
+        str | None,
+        typer.Option(
+            "--model",
+            "-m",
+            help="Ollama model for all LLM opponents (overrides YAML profiles)",
+        ),
+    ] = None,
     override: Annotated[
         list[str] | None,
         typer.Option(
@@ -80,6 +123,8 @@ def train(
         overrides["device"] = device
     if timesteps is not None:
         overrides["total_timesteps"] = str(timesteps)
+    if model is not None:
+        overrides["self_play.llm_model"] = model
     if override:
         for o in override:
             if "=" not in o:
@@ -88,6 +133,7 @@ def train(
             overrides[key] = value
 
     cfg = merge_cli_overrides(cfg, overrides)
+    _preflight_validate_model(cfg)
     typer.echo(f"Training with config: {cfg}")
 
     from training.self_play import SelfPlayTrainer

--- a/src/agents/llm_opponent.py
+++ b/src/agents/llm_opponent.py
@@ -12,13 +12,11 @@ import torch
 
 from src.agents.base import Agent
 from src.agents.ollama_client import call_ollama_for_action_index
-from src.agents.player_config import PlayerConfig
+from src.agents.player_config import DEFAULT_MODEL, PlayerConfig
 from src.agents.random_agent import RandomAgent
 from src.utils.log import get_logger
 
 logger = get_logger("llm_opponent")
-
-DEFAULT_MODEL = "gpt-oss:120b"
 
 
 class LLMOpponent(Agent):

--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -134,6 +134,36 @@ def call_ollama_for_action_index(
     return _parse_index(data, legal_actions, model, elapsed)
 
 
+def list_ollama_models(
+    base_url: str | None = None,
+    api_key: str | None = None,
+    timeout: float = 10.0,
+) -> set[str] | None:
+    """Return the set of model ids the Ollama server advertises, or ``None``.
+
+    Queries the OpenAI-compatible ``GET {base}/models`` endpoint. ``base_url`` /
+    ``api_key`` fall back to ``OLLAMA_BASE_URL`` / ``OLLAMA_API_KEY`` then the
+    local defaults — same resolution as :func:`call_ollama_for_action_index`.
+
+    Returns ``None`` (rather than raising) on any connection / HTTP / parse
+    error, so callers can treat "unknown" as "skip validation and proceed"
+    instead of crashing a valid run on a flaky probe.
+    """
+    ensure_env_loaded()
+    base = (base_url or os.environ.get(ENV_BASE_URL) or DEFAULT_BASE_URL).rstrip("/")
+    key = api_key or os.environ.get(ENV_API_KEY) or DEFAULT_API_KEY
+    url = f"{base}/models"
+    headers = {"Authorization": f"Bearer {key}"}
+    try:
+        response = httpx.get(url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+        return {entry["id"] for entry in data.get("data", []) if "id" in entry}
+    except (httpx.HTTPError, KeyError, ValueError, TypeError) as exc:
+        _log.warning("Could not list Ollama models from %s: %s", url, exc)
+        return None
+
+
 _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
 _INDEX_RE = re.compile(r'"?action_index"?\s*[:=]\s*(-?\d+)')
 
@@ -194,4 +224,10 @@ def _parse_index(
     return None
 
 
-__all__ = ["call_ollama_for_action_index", "ENV_BASE_URL", "ENV_API_KEY", "DEFAULT_BASE_URL"]
+__all__ = [
+    "call_ollama_for_action_index",
+    "list_ollama_models",
+    "ENV_BASE_URL",
+    "ENV_API_KEY",
+    "DEFAULT_BASE_URL",
+]

--- a/src/agents/player_config.py
+++ b/src/agents/player_config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import yaml
 
-DEFAULT_MODEL = "gpt-oss:120b"
+DEFAULT_MODEL = "gemma4:12b-mlx"
 
 
 @dataclass(frozen=True)

--- a/src/config.py
+++ b/src/config.py
@@ -63,6 +63,7 @@ class SelfPlayConfig:
     eval_games: int = 10
     n_players: int = 2
     llm_profiles_path: str | None = None
+    llm_model: str | None = None  # uniform model override for all LLM opponents
 
 
 @dataclass(frozen=True)

--- a/tests/test_llm_opponent.py
+++ b/tests/test_llm_opponent.py
@@ -145,7 +145,7 @@ class TestConfiguration:
 
     def test_default_values(self) -> None:
         a = LLMOpponent()
-        assert a._model == "gpt-oss:120b"
+        assert a._model == "gemma4:12b-mlx"
         assert a._timeout == 30.0
         assert a._temperature == 0.1
 
@@ -226,7 +226,7 @@ class TestOllamaWiring:
             a.act(dummy_obs, dummy_legal)
         mock_call.assert_called_once()
         kwargs = mock_call.call_args.kwargs
-        assert kwargs["model"] == "gpt-oss:120b"
+        assert kwargs["model"] == "gemma4:12b-mlx"
         assert kwargs["base_url"] == "http://localhost:11434/v1"
         assert kwargs["api_key"] == "test-key"
         assert kwargs["temperature"] == pytest.approx(0.7)

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -1,0 +1,142 @@
+"""Tests for the ``--model`` train override and Ollama model pre-flight check.
+
+Covers the wiring added so ``risiko-rl train --model <name>`` swaps the model
+for every LLM opponent uniformly, plus the startup validation that fails fast
+when a requested model is not available on the Ollama server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from risiko_rl.cli import _preflight_validate_model
+from src.config import SelfPlayConfig, TrainingConfig, merge_cli_overrides
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_6P = str(PROJECT_ROOT / "config" / "default_6p.yaml")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Config: self_play.llm_model round-trip
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestLlmModelOverrideConfig:
+    def test_when_field_omitted_then_defaults_to_none(self) -> None:
+        assert SelfPlayConfig().llm_model is None
+
+    def test_when_overridden_then_round_trips_through_cli_merge(self) -> None:
+        cfg = TrainingConfig(self_play=SelfPlayConfig(llm_profiles_path="x"))
+        merged = merge_cli_overrides(cfg, {"self_play.llm_model": "kimi-k2.6:cloud"})
+        assert merged.self_play.llm_model == "kimi-k2.6:cloud"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _build_llm_opponents: uniform model override, per-slot sampling preserved
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildLlmOpponentsModelOverride:
+    def test_when_llm_model_set_then_all_opponents_use_it(self) -> None:
+        from training.self_play import _build_llm_opponents
+
+        opponents = _build_llm_opponents(6, DEFAULT_6P, llm_model="custom:model")
+        assert len(opponents) == 5
+        assert all(op is not None and op._model == "custom:model" for op in opponents)
+
+    def test_when_llm_model_set_then_per_slot_sampling_is_preserved(self) -> None:
+        from training.self_play import _build_llm_opponents
+
+        opponents = _build_llm_opponents(6, DEFAULT_6P, llm_model="custom:model")
+        # First five profiles (player_id 0..4) have these temperatures.
+        assert [round(op._temperature, 1) for op in opponents] == [0.1, 0.4, 0.7, 0.3, 0.9]
+
+    def test_when_llm_model_omitted_then_profile_models_are_kept(self) -> None:
+        from training.self_play import _build_llm_opponents
+
+        opponents = _build_llm_opponents(6, DEFAULT_6P)
+        assert all(op._model == "gemma4:12b-mlx" for op in opponents)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# list_ollama_models: parse the /v1/models payload, swallow errors as None
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _fake_models_response(ids: list[str]) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"data": [{"id": i} for i in ids]}
+    return resp
+
+
+class TestListOllamaModels:
+    def test_when_server_responds_then_returns_id_set(self) -> None:
+        with (
+            patch("src.agents.ollama_client.ensure_env_loaded", return_value=None),
+            patch(
+                "src.agents.ollama_client.httpx.get",
+                return_value=_fake_models_response(["gemma4:12b-mlx", "glm-5.1:cloud"]),
+            ),
+        ):
+            from src.agents.ollama_client import list_ollama_models
+
+            assert list_ollama_models() == {"gemma4:12b-mlx", "glm-5.1:cloud"}
+
+    def test_when_http_error_then_returns_none(self) -> None:
+        import httpx
+
+        with (
+            patch("src.agents.ollama_client.ensure_env_loaded", return_value=None),
+            patch(
+                "src.agents.ollama_client.httpx.get",
+                side_effect=httpx.ConnectError("refused"),
+            ),
+        ):
+            from src.agents.ollama_client import list_ollama_models
+
+            assert list_ollama_models() is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI pre-flight: fail fast on missing model, proceed on unknown/available
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _llm_cfg(model: str | None) -> TrainingConfig:
+    return TrainingConfig(self_play=SelfPlayConfig(llm_profiles_path=DEFAULT_6P, llm_model=model))
+
+
+class TestPreflightValidateModel:
+    def test_when_model_missing_then_raises_bad_parameter(self) -> None:
+        with (
+            patch(
+                "src.agents.ollama_client.list_ollama_models",
+                return_value={"gemma4:12b-mlx"},
+            ),
+            pytest.raises(typer.BadParameter),
+        ):
+            _preflight_validate_model(_llm_cfg("not-a-real-model"))
+
+    def test_when_model_available_then_passes(self) -> None:
+        with patch(
+            "src.agents.ollama_client.list_ollama_models",
+            return_value={"glm-5.1:cloud", "gemma4:12b-mlx"},
+        ):
+            _preflight_validate_model(_llm_cfg("glm-5.1:cloud"))  # no raise
+
+    def test_when_server_unreachable_then_proceeds(self) -> None:
+        with patch("src.agents.ollama_client.list_ollama_models", return_value=None):
+            _preflight_validate_model(_llm_cfg("anything:latest"))  # no raise
+
+    def test_when_no_profiles_path_then_skips_validation(self) -> None:
+        # self-play mode: no LLM opponents → never queries the server.
+        with patch(
+            "src.agents.ollama_client.list_ollama_models",
+            side_effect=AssertionError("should not be called"),
+        ):
+            _preflight_validate_model(TrainingConfig(self_play=SelfPlayConfig()))

--- a/tests/test_player_config.py
+++ b/tests/test_player_config.py
@@ -29,14 +29,14 @@ class TestPlayerConfigFrozen:
         with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
             cfg.temperature = 0.5  # type: ignore[misc]
 
-    def test_when_model_omitted_defaults_to_gpt_oss_120b(self) -> None:
+    def test_when_model_omitted_defaults_to_gemma4(self) -> None:
         cfg = PlayerConfig(
             player_id=0,
             temperature=0.1,
             top_p=0.9,
             strategy_hint="hint",
         )
-        assert cfg.model == "gpt-oss:120b"
+        assert cfg.model == "gemma4:12b-mlx"
         assert cfg.model == DEFAULT_MODEL
 
     def test_when_model_provided_stores_value(self) -> None:
@@ -127,8 +127,8 @@ class TestDefault6PProfiles:
         ids = [p.player_id for p in DEFAULT_6P_PROFILES]
         assert len(set(ids)) == len(ids)
 
-    def test_when_checking_all_models_default_to_gpt_oss_120b(self) -> None:
-        assert all(p.model == "gpt-oss:120b" for p in DEFAULT_6P_PROFILES)
+    def test_when_checking_all_models_default_to_gemma4(self) -> None:
+        assert all(p.model == "gemma4:12b-mlx" for p in DEFAULT_6P_PROFILES)
 
 
 class TestLoadProfilesFromYaml:
@@ -156,7 +156,7 @@ class TestLoadProfilesFromYaml:
         assert profiles[0].player_id == 0
         assert profiles[0].temperature == pytest.approx(0.5)
 
-    def test_when_yaml_omits_model_field_defaults_to_gpt_oss_120b(self, tmp_path: Path) -> None:
+    def test_when_yaml_omits_model_field_defaults_to_gemma4(self, tmp_path: Path) -> None:
         data = [
             {
                 "player_id": 0,
@@ -168,7 +168,7 @@ class TestLoadProfilesFromYaml:
         path = tmp_path / "profiles.yaml"
         path.write_text(yaml.dump(data))
         profiles = load_profiles_from_yaml(path)
-        assert profiles[0].model == "gpt-oss:120b"
+        assert profiles[0].model == "gemma4:12b-mlx"
 
     def test_when_yaml_has_duplicate_player_ids_raises_value_error(self, tmp_path: Path) -> None:
         data = [

--- a/tests/test_player_profiles_default.py
+++ b/tests/test_player_profiles_default.py
@@ -2,7 +2,7 @@
 
 Criteria covered:
   [UNIT] PlayerConfig is a frozen dataclass with player_id, temperature,
-         top_p, strategy_hint, model (default "gpt-oss:120b")
+         top_p, strategy_hint, model (default "gemma4:12b-mlx")
   [UNIT] DEFAULT_6P_PROFILES matches the six-profile table exactly
   [UNIT] load_profiles_from_yaml() round-trips config/default_6p.yaml;
          raises ValueError on out-of-range (player_id not in 0–5) or
@@ -57,10 +57,10 @@ def _write_profiles_yaml(profiles: list[PlayerConfig], path: str | pathlib.Path)
 class TestPlayerConfigDataclass:
     """Frozen dataclass contract for PlayerConfig."""
 
-    def test_when_model_omitted_then_default_is_gpt_oss_120b(self):
-        """Criterion: model field defaults to 'gpt-oss:120b'."""
+    def test_when_model_omitted_then_default_is_gemma4(self):
+        """Criterion: model field defaults to 'gemma4:12b-mlx'."""
         pc = PlayerConfig(player_id=0, temperature=0.5, top_p=0.9, strategy_hint="hint")
-        assert pc.model == "gpt-oss:120b"
+        assert pc.model == "gemma4:12b-mlx"
 
     def test_when_all_fields_supplied_then_fields_are_stored_correctly(self):
         """Criterion: PlayerConfig has player_id, temperature, top_p, strategy_hint, model."""
@@ -136,11 +136,11 @@ class TestDefault6PProfiles:
         )
         assert profile.strategy_hint == strategy_hint, f"player {player_id}: strategy_hint mismatch"
 
-    def test_when_all_default_models_checked_then_every_profile_uses_gpt_oss_120b(self):
-        """Criterion: default model for all profiles is 'gpt-oss:120b'."""
+    def test_when_all_default_models_checked_then_every_profile_uses_gemma4(self):
+        """Criterion: default model for all profiles is 'gemma4:12b-mlx'."""
         for profile in DEFAULT_6P_PROFILES:
-            assert profile.model == "gpt-oss:120b", (
-                f"player {profile.player_id} has model={profile.model!r}, expected 'gpt-oss:120b'"
+            assert profile.model == "gemma4:12b-mlx", (
+                f"player {profile.player_id} has model={profile.model!r}, expected 'gemma4:12b-mlx'"
             )
 
     def test_when_default_profiles_checked_then_no_duplicate_player_ids_exist(self):

--- a/training/self_play.py
+++ b/training/self_play.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import random
 from datetime import datetime
 from pathlib import Path
@@ -37,6 +38,7 @@ _OPPONENT_ID: int = 1
 def _build_llm_opponents(
     n_players: int,
     llm_profiles_path: str | None,
+    llm_model: str | None = None,
 ) -> list[LLMOpponent | None]:
     """Build N-1 opponent slots from a profile YAML or return None fillers.
 
@@ -44,6 +46,8 @@ def _build_llm_opponents(
         n_players: Total number of players (learner + opponents).
         llm_profiles_path: Path to a YAML profile list, or ``None`` for
             self-play / random-filler mode.
+        llm_model: If set, override every profile's model with this name,
+            keeping each slot's temperature / top_p / strategy_hint.
 
     Returns:
         A list of ``n_players - 1`` items: ``LLMOpponent`` instances when
@@ -53,10 +57,17 @@ def _build_llm_opponents(
     if not llm_profiles_path:
         return [None] * n_opponents
     profiles = load_profiles_from_yaml(Path(llm_profiles_path))
+    if llm_model:
+        profiles = [dataclasses.replace(p, model=llm_model) for p in profiles]
     opponents: list[LLMOpponent | None] = [
         LLMOpponent(player_config=profiles[i % len(profiles)]) for i in range(n_opponents)
     ]
-    _log.info("LLM mode: loaded %d opponents from %s", n_opponents, llm_profiles_path)
+    _log.info(
+        "LLM mode: loaded %d opponents from %s (model=%s)",
+        n_opponents,
+        llm_profiles_path,
+        llm_model or "per-profile",
+    )
     return opponents
 
 
@@ -231,6 +242,7 @@ class SelfPlayTrainer:
         slots = _build_llm_opponents(
             self._cfg.self_play.n_players,
             self._cfg.self_play.llm_profiles_path,
+            self._cfg.self_play.llm_model,
         )
         if not self._cfg.self_play.llm_profiles_path:
             return None


### PR DESCRIPTION
## What

Add `risiko-rl train --model <name>` to override the model for **all** LLM opponents uniformly, keeping each slot's `temperature`/`top_p`/`strategy_hint`. The model is validated against the live Ollama model list at startup, so a typo or unpulled model **fails fast** instead of silently degrading every opponent to `RandomAgent` for an entire run.

Also fixes a stale default: `gpt-oss:120b` is not available on the local Ollama server. Default is now `gemma4:12b-mlx` (local, free) across `PlayerConfig`, `DEFAULT_6P_PROFILES`, and `config/default_6p.yaml`.

## Changes

- `src/config.py` — add `SelfPlayConfig.llm_model` field (overridable via `--override self_play.llm_model=...` too)
- `risiko_rl/cli.py` — `--model/-m` option + `_preflight_validate_model()`
- `training/self_play.py` — `_build_llm_opponents()` applies uniform override via `dataclasses.replace`
- `src/agents/ollama_client.py` — `list_ollama_models()` helper (GET `/v1/models`; returns `None` on error → warn + proceed)
- `src/agents/llm_opponent.py` — single-source `DEFAULT_MODEL` from `player_config`
- `config/default_6p.yaml` — `gpt-oss:120b` → `gemma4:12b-mlx` (all 6 slots)
- tests — update default assertions in 3 files + new `tests/test_model_override.py` (11 tests)

## Usage

```bash
risiko-rl train --config config/llm_6p.yaml --model glm-5.1:cloud
risiko-rl train --config config/llm_6p.yaml --model gemma4:12b-mlx
risiko-rl train --config config/llm_6p.yaml          # default gemma4:12b-mlx
```

## Verify

- Full suite green (2 pre-existing skips), `ruff check`/`format` clean
- `--help` shows the flag; live pre-flight fail-fast confirmed against a running Ollama server (lists available models on a bad `--model`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)