### PR TITLE
fix(ollama): raise timeout/max_tokens + reasoning-field fallback for glm

### DIFF
--- a/src/agents/llm_opponent.py
+++ b/src/agents/llm_opponent.py
@@ -25,7 +25,7 @@ class LLMOpponent(Agent):
     def __init__(
         self,
         model: str = DEFAULT_MODEL,
-        timeout: float = 30.0,
+        timeout: float = 120.0,
         temperature: float = 0.1,
         *,
         top_p: float = 0.9,

--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -46,7 +46,7 @@ ENV_API_KEY = "OLLAMA_API_KEY"
 
 DEFAULT_BASE_URL = "http://localhost:11434/v1"
 DEFAULT_API_KEY = "ollama"  # placeholder; Ollama ignores it for local serving
-DEFAULT_MAX_TOKENS = 4096  # reasoning models (gpt-oss, glm) think before the JSON; leave room
+DEFAULT_MAX_TOKENS = 8192  # reasoning models (gpt-oss, glm) think before the JSON; leave room
 
 _RESPONSE_FORMAT: dict[str, Any] = {
     "type": "json_schema",
@@ -70,7 +70,7 @@ def call_ollama_for_action_index(
     model: str,
     base_url: str | None = None,
     api_key: str | None = None,
-    timeout: float = 30.0,
+    timeout: float = 120.0,
     temperature: float = 0.1,
     top_p: float | None = None,
     strategy_hint: str | None = None,
@@ -196,12 +196,28 @@ def _parse_index(
 ) -> int | None:
     """Extract and range-check ``action_index`` from a chat-completions reply."""
     choices = data.get("choices") or []
-    content = choices[0].get("message", {}).get("content", "") if choices else ""
+    message = choices[0].get("message", {}) if choices else {}
+    content = message.get("content", "") or ""
+    finish_reason = choices[0].get("finish_reason") if choices else None
     usage = data.get("usage", {})
     completion_tokens = usage.get("completion_tokens", 0)
     if not content:
-        _log.warning("Ollama returned empty content (model=%s, %.2fs)", model, elapsed)
-        return None
+        # Reasoning models (glm, gpt-oss) sometimes emit the answer only in a
+        # `reasoning` / `reasoning_content` field, or exhaust max_tokens on the
+        # thinking trace (finish_reason="length") and return empty content.
+        # Try the reasoning text before giving up — the index regex still works.
+        reasoning = message.get("reasoning") or message.get("reasoning_content") or ""
+        if reasoning:
+            content = reasoning
+        else:
+            _log.warning(
+                "Ollama returned empty content (model=%s, %.2fs, finish_reason=%s, tok=%d)",
+                model,
+                elapsed,
+                finish_reason,
+                completion_tokens,
+            )
+            return None
     idx = _extract_action_index(content)
     if idx is None:
         _log.warning("Ollama reply has no usable action_index | raw=%r", content)

--- a/tests/test_llm_opponent.py
+++ b/tests/test_llm_opponent.py
@@ -146,7 +146,7 @@ class TestConfiguration:
     def test_default_values(self) -> None:
         a = LLMOpponent()
         assert a._model == "gemma4:12b-mlx"
-        assert a._timeout == 30.0
+        assert a._timeout == 120.0
         assert a._temperature == 0.1
 
     def test_custom_values(self) -> None:


### PR DESCRIPTION
## Problem

Training the PPO agent against `glm-5.1:cloud` (`config/llm_6p.yaml`) surfaced two LLM-opponent failure modes — both ending in a `RandomAgent` fallback, so the LLM wasn't actually playing:

1. **Timeout mid-reasoning** — glm-5.1 is a reasoning model; it thinks before emitting the JSON answer. The 30s per-call timeout fired during reasoning → `fallback: timeout`.
2. **Empty `content`** — the 4096-token completion cap was exhausted by the reasoning trace, leaving the final `content` field empty → `empty_or_invalid_response` fallback. Observed at 41–58s calls.

## Fix

- Raise per-call timeout **30s → 120s** (`LLMOpponent.__init__` + `call_ollama_for_action_index`).
- Raise `DEFAULT_MAX_TOKENS` **4096 → 8192` — reasoning headroom.
- `_parse_index`: when `content` is empty, fall back to the `reasoning` / `reasoning_content` field before giving up (the `action_index` regex still works), and log `finish_reason` + token count on genuine empties for diagnosis.

## Verification

Relaunched `risiko-rl train --config config/llm_6p.yaml --model glm-5.1:cloud`. After the fix, over the first batch of LLM calls:

| metric | before-style | after |
|--------|--------------|-------|
| empty `content` | dominant failure (41–58s calls) | **0** |
| 30s timeouts | constant | **0** (raised to 120s) |
| successes | — | flowing, 2.8–77s |

Direct proof the token bump matters — these now succeed instead of returning empty:

```
31.80s, 4663 tok   ← above old 4096 cap
77.05s, 5607 tok   ← well above 4096 cap
```

Residual (rare, benign): occasional single call still spikes past the 8192/120s ceilings → one random move, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)