### PR TITLE
fix(ollama): use native /api/chat enforced `format` for structured output

### DIFF
--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -1,9 +1,16 @@
 """Ollama chat-completions client for action selection (local or cloud).
 
 The LLM is asked to pick an INDEX into the ``legal_actions`` list. Output is
-constrained to ``{"action_index": <int>}`` via the OpenAI-compatible
-``response_format`` (json_schema, ``strict: true``) so the reply is tiny and
-guaranteed parseable; the chosen action is always legal by construction.
+constrained to ``{"action_index": <int>}`` via Ollama's NATIVE ``/api/chat``
+``format`` field (a raw JSON schema enforced with XGrammar constrained
+decoding) so the reply is tiny and guaranteed parseable; the chosen action is
+always legal by construction.
+
+Why not the OpenAI-compatible ``/v1/chat/completions`` ``response_format``?
+Ollama only honours that as loose "JSON mode" and silently ignores the
+json_schema for many models (ollama#10937, #10001) — reasoning models such as
+``glm`` then free-reason in prose and never emit the schema. The native
+``format`` field is actually enforced, so we target ``/api/chat`` instead.
 
 One client serves both deployment modes — they differ only in ``base_url``,
 the API key, and the model name:
@@ -14,14 +21,15 @@ the API key, and the model name:
 * **Cloud (Ollama Turbo):** ``OLLAMA_BASE_URL=https://ollama.com/v1`` with
   ``OLLAMA_API_KEY=<key>`` and a hosted model (e.g. ``gpt-oss:120b``).
 
-Endpoint (OpenAI-compatible; the base URL already ends in ``/v1``):
-    {OLLAMA_BASE_URL}/chat/completions
+Endpoint: the base URL ends in ``/v1`` (for the model-list probe); the client
+strips it and calls the native ``{root}/api/chat``. Auth uses the standard
+``Authorization: Bearer <key>`` header.
 
-Auth uses the standard ``Authorization: Bearer <key>`` header.
-
-Note on reasoning models: ``gpt-oss`` reasons before emitting the final JSON,
-which consumes completion tokens. ``max_tokens`` is therefore sized to leave
-room for that hidden reasoning rather than the ~10-token answer alone.
+Note on reasoning models: ``glm`` / ``gpt-oss`` reason before emitting the
+final JSON, which consumes completion tokens, and the ``format`` mask only
+applies after the end-of-thinking token — so thinking is kept ENABLED
+(``think: true``; ollama#15260) and ``num_predict`` (``max_tokens``) is sized
+to leave room for the hidden reasoning, not just the ~10-token answer.
 """
 
 from __future__ import annotations
@@ -46,20 +54,18 @@ ENV_API_KEY = "OLLAMA_API_KEY"
 
 DEFAULT_BASE_URL = "http://localhost:11434/v1"
 DEFAULT_API_KEY = "ollama"  # placeholder; Ollama ignores it for local serving
-DEFAULT_MAX_TOKENS = 8192  # reasoning models (gpt-oss, glm) think before the JSON; leave room
+DEFAULT_MAX_TOKENS = 16384  # reasoning models (gpt-oss, glm) think before the JSON; leave room
 
-_RESPONSE_FORMAT: dict[str, Any] = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "action_choice",
-        "strict": True,
-        "schema": {
-            "type": "object",
-            "properties": {"action_index": {"type": "integer"}},
-            "required": ["action_index"],
-            "additionalProperties": False,
-        },
-    },
+# Raw JSON schema for Ollama's NATIVE /api/chat `format` field. Unlike the
+# OpenAI-compatible /v1 `response_format` (which Ollama only honours as loose
+# "JSON mode" and silently ignores for many models — ollama#10937, #10001),
+# the native `format` is enforced via XGrammar constrained decoding, so the
+# reply is guaranteed to match this schema.
+_ACTION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"action_index": {"type": "integer"}},
+    "required": ["action_index"],
+    "additionalProperties": False,
 }
 
 
@@ -110,14 +116,25 @@ def call_ollama_for_action_index(
     body: dict[str, Any] = {
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
-        "response_format": _RESPONSE_FORMAT,
-        "temperature": temperature,
-        "max_tokens": max_tokens,
+        "format": _ACTION_SCHEMA,  # enforced via XGrammar on the native endpoint
+        "stream": False,
+        # Keep thinking ENABLED. For reasoning models (glm, gpt-oss) Ollama
+        # defers the `format` probability mask until the end-of-thinking token;
+        # think=false closes the thinking tags without that token, so the mask
+        # never applies and the schema is ignored (ollama#15260). With thinking
+        # on, the model reasons, then constrained decoding forces the JSON.
+        "think": True,
+        "options": {
+            "temperature": temperature,
+            "num_predict": max_tokens,
+        },
     }
     if top_p is not None:
-        body["top_p"] = top_p
+        body["options"]["top_p"] = top_p
 
-    url = f"{base}/chat/completions"
+    # Native /api/chat (NOT the OpenAI-compat /v1) — `base` ends in /v1, strip it.
+    root = base[:-3] if base.endswith("/v1") else base
+    url = f"{root}/api/chat"
     headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
     _log.debug(
         "---PROMPT--- model=%s temp=%.2f n_legal=%d\n%s",
@@ -171,9 +188,11 @@ _INDEX_RE = re.compile(r'"?action_index"?\s*[:=]\s*(-?\d+)')
 def _extract_action_index(content: str) -> int | None:
     """Pull an integer ``action_index`` out of a model reply, tolerantly.
 
-    Not all Ollama models honour ``response_format`` json_schema; reasoning
-    models in particular wrap the answer in a ```json fence or add prose. Try
-    strict JSON first, then a fenced-JSON unwrap, then a regex fallback.
+    Output shape varies by backend: the native ``format`` schema yields
+    ``{"action_index": <int>}`` locally, but cloud-proxied models often flatten
+    the single-property object to a bare integer (e.g. ``"0"``); reasoning
+    models may also wrap the answer in a ```json fence or add prose. Try strict
+    JSON (object *or* bare int) first, then a fenced-JSON unwrap, then regex.
     """
     candidates = [content.strip()]
     fenced = _FENCE_RE.search(content)
@@ -181,9 +200,17 @@ def _extract_action_index(content: str) -> int | None:
         candidates.append(fenced.group(1).strip())
     for candidate in candidates:
         try:
-            return int(json.loads(candidate)["action_index"])
-        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
             continue
+        # Bare integer (cloud schema-flattening): "0" -> 0. Exclude bool.
+        if isinstance(parsed, int) and not isinstance(parsed, bool):
+            return parsed
+        if isinstance(parsed, dict) and "action_index" in parsed:
+            try:
+                return int(parsed["action_index"])
+            except (ValueError, TypeError):
+                continue
     match = _INDEX_RE.search(content)
     return int(match.group(1)) if match else None
 
@@ -195,26 +222,26 @@ def _parse_index(
     elapsed: float,
 ) -> int | None:
     """Extract and range-check ``action_index`` from a chat-completions reply."""
-    choices = data.get("choices") or []
-    message = choices[0].get("message", {}) if choices else {}
+    # Native /api/chat shape: {"message": {"content", "thinking"}, "eval_count",
+    # "done_reason"} — not the OpenAI-compat {"choices": [...], "usage": ...}.
+    message = data.get("message") or {}
     content = message.get("content", "") or ""
-    finish_reason = choices[0].get("finish_reason") if choices else None
-    usage = data.get("usage", {})
-    completion_tokens = usage.get("completion_tokens", 0)
+    completion_tokens = data.get("eval_count", 0)
+    done_reason = data.get("done_reason")
     if not content:
-        # Reasoning models (glm, gpt-oss) sometimes emit the answer only in a
-        # `reasoning` / `reasoning_content` field, or exhaust max_tokens on the
-        # thinking trace (finish_reason="length") and return empty content.
-        # Try the reasoning text before giving up — the index regex still works.
-        reasoning = message.get("reasoning") or message.get("reasoning_content") or ""
-        if reasoning:
-            content = reasoning
+        # With `format` enforced, content should already be schema-valid JSON.
+        # If it is empty (e.g. num_predict exhausted mid-thinking,
+        # done_reason="length"), fall back to the thinking trace — the index
+        # regex may still recover a number before giving up to RandomAgent.
+        thinking = message.get("thinking") or message.get("reasoning") or ""
+        if thinking:
+            content = thinking
         else:
             _log.warning(
-                "Ollama returned empty content (model=%s, %.2fs, finish_reason=%s, tok=%d)",
+                "Ollama returned empty content (model=%s, %.2fs, done_reason=%s, tok=%d)",
                 model,
                 elapsed,
-                finish_reason,
+                done_reason,
                 completion_tokens,
             )
             return None

--- a/tests/test_ac60.py
+++ b/tests/test_ac60.py
@@ -1,7 +1,7 @@
 """Source-blind acceptance-criteria tests for issue #60 — migrated to Ollama contract.
 
 Criteria covered (oracle-verified as UNIT or T2):
-  [T2]   LLM calls /chat/completions with json_schema strict output
+  [T2]   LLM calls the native /api/chat endpoint with an enforced `format` schema
   [UNIT] Ollama credentials in .env; .env.example committed
   [UNIT] LLM output is an index into legal_actions
   [UNIT] render_action_prompt() is single source of truth; no hardcoded API key
@@ -63,9 +63,7 @@ def _make_legal_actions() -> list[dict[str, int]]:
 def _fake_httpx_response(action_index: int = 0) -> MagicMock:
     """Return a MagicMock that looks like a successful httpx response."""
     resp = MagicMock()
-    resp.json.return_value = {
-        "choices": [{"message": {"content": json.dumps({"action_index": action_index})}}]
-    }
+    resp.json.return_value = {"message": {"content": json.dumps({"action_index": action_index})}}
     resp.raise_for_status.return_value = None
     resp.status_code = 200
     return resp
@@ -111,7 +109,7 @@ class TestOllamaCredentialFiles:
 
 
 # ===========================================================================
-# Criterion [T2]: LLM calls /chat/completions with json_schema strict output
+# Criterion [T2]: LLM calls the native /api/chat with an enforced `format` schema
 # ===========================================================================
 
 
@@ -126,7 +124,7 @@ class TestOllamaApiContractStrict:
     Intercepts httpx.post and asserts on the request URL and body.
     """
 
-    def test_when_action_requested_then_url_contains_chat_completions(
+    def test_when_action_requested_then_url_targets_api_chat(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from src.agents.ollama_client import call_ollama_for_action_index
@@ -139,11 +137,13 @@ class TestOllamaApiContractStrict:
                 _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
-        assert "/chat/completions" in captured.get("url", ""), (
-            f"Request must target /chat/completions; got url={captured.get('url')!r}"
+        url = captured.get("url", "")
+        assert url.endswith("/api/chat"), (
+            f"Request must target the native /api/chat; got url={url!r}"
         )
+        assert "/v1/" not in url, f"Native endpoint must not contain /v1/; got url={url!r}"
 
-    def test_when_action_requested_then_response_format_type_is_json_schema(
+    def test_when_action_requested_then_format_type_is_object(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from src.agents.ollama_client import call_ollama_for_action_index
@@ -159,12 +159,10 @@ class TestOllamaApiContractStrict:
                 _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
-        rf = captured.get("body", {}).get("response_format", {})
-        assert rf.get("type") == "json_schema", (
-            f"response_format.type must be 'json_schema', got {rf!r}"
-        )
+        fmt = captured.get("body", {}).get("format", {})
+        assert fmt.get("type") == "object", f"format.type must be 'object', got {fmt!r}"
 
-    def test_when_action_requested_then_json_schema_strict_is_true(
+    def test_when_action_requested_then_format_schema_requires_action_index(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from src.agents.ollama_client import call_ollama_for_action_index
@@ -180,10 +178,12 @@ class TestOllamaApiContractStrict:
                 _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.5
             )
 
-        rf = captured.get("body", {}).get("response_format", {})
-        schema_block = rf.get("json_schema", {})
-        assert schema_block.get("strict") is True, (
-            f"response_format.json_schema.strict must be True; got {schema_block!r}"
+        fmt = captured.get("body", {}).get("format", {})
+        assert "action_index" in fmt.get("required", []), (
+            f"format schema must require 'action_index'; got {fmt!r}"
+        )
+        assert fmt.get("properties", {}).get("action_index", {}).get("type") == "integer", (
+            f"action_index must be typed integer; got {fmt!r}"
         )
 
     def test_when_action_requested_then_authorization_bearer_header_is_present(
@@ -226,9 +226,9 @@ class TestOllamaApiContractStrict:
                 _make_obs(), _make_legal_actions(), model="gpt-oss:120b", temperature=0.3
             )
 
-        assert captured.get("body", {}).get("temperature") == pytest.approx(0.3), (
-            "temperature must appear in the request body"
-        )
+        assert captured.get("body", {}).get("options", {}).get("temperature") == pytest.approx(
+            0.3
+        ), "temperature must appear in the request options"
 
     def test_when_action_requested_then_top_p_is_injected_in_body(
         self, monkeypatch: pytest.MonkeyPatch
@@ -250,8 +250,8 @@ class TestOllamaApiContractStrict:
                 top_p=0.85,
             )
 
-        assert captured.get("body", {}).get("top_p") == pytest.approx(0.85), (
-            "top_p must appear in the request body when provided"
+        assert captured.get("body", {}).get("options", {}).get("top_p") == pytest.approx(0.85), (
+            "top_p must appear in the request options when provided"
         )
 
 

--- a/tests/test_ac61.py
+++ b/tests/test_ac61.py
@@ -36,7 +36,7 @@ _PROJECT_ROOT = pathlib.Path(__file__).parent.parent
 def _fake_httpx_response(action_index: int = 0) -> MagicMock:
     """Return a mock that looks like an httpx.Response from Ollama."""
     content = json.dumps({"action_index": action_index})
-    body = {"choices": [{"message": {"content": content}}]}
+    body = {"message": {"content": content}}
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = body
@@ -85,13 +85,13 @@ def _write_player_profiles(path: pathlib.Path, n: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# [T2] LLM opponent calls Ollama via /chat/completions
-#      with json_schema strict output
+# [T2] LLM opponent calls Ollama via the native /api/chat endpoint
+#      with an enforced JSON-schema `format` field
 # ---------------------------------------------------------------------------
 
 
 class TestOllamaApiContract:
-    """The Ollama client must POST to /chat/completions with json_schema strict."""
+    """The Ollama client must POST to the native /api/chat with an enforced `format`."""
 
     def _call_with_capture(self, monkeypatch) -> dict:
         """Call call_ollama_for_action_index; return the captured httpx.post kwargs."""
@@ -118,38 +118,36 @@ class TestOllamaApiContract:
             )
         return captured
 
-    def test_when_action_requested_then_url_contains_chat_completions(self, monkeypatch) -> None:
-        """POST URL must contain /chat/completions."""
+    def test_when_action_requested_then_url_targets_api_chat(self, monkeypatch) -> None:
+        """POST URL must target the native /api/chat endpoint."""
         captured = self._call_with_capture(monkeypatch)
-        assert "/chat/completions" in captured["url"], (
-            f"Expected /chat/completions in URL; got {captured['url']!r}"
+        assert captured["url"].endswith("/api/chat"), (
+            f"Expected URL to end with /api/chat; got {captured['url']!r}"
+        )
+        assert "/v1/" not in captured["url"], (
+            f"Native endpoint must not contain /v1/; got {captured['url']!r}"
         )
 
-    def test_when_action_requested_then_response_format_type_is_json_schema(
-        self, monkeypatch
-    ) -> None:
-        """Request body must have response_format.type == 'json_schema'."""
+    def test_when_action_requested_then_format_type_is_object(self, monkeypatch) -> None:
+        """Request body must have format.type == 'object' (raw schema)."""
         captured = self._call_with_capture(monkeypatch)
         body = captured["kwargs"].get("json", {})
-        rf = body.get("response_format", {})
-        assert rf.get("type") == "json_schema", (
-            f"response_format.type must be 'json_schema'; got {rf!r}"
-        )
+        fmt = body.get("format", {})
+        assert fmt.get("type") == "object", f"format.type must be 'object'; got {fmt!r}"
 
-    def test_when_action_requested_then_json_schema_strict_is_true(self, monkeypatch) -> None:
-        """Request body must have response_format.json_schema.strict == True."""
+    def test_when_action_requested_then_thinking_is_enabled(self, monkeypatch) -> None:
+        """Request body must enable thinking so the `format` mask is applied."""
         captured = self._call_with_capture(monkeypatch)
         body = captured["kwargs"].get("json", {})
-        schema_wrapper = body.get("response_format", {}).get("json_schema", {})
-        assert schema_wrapper.get("strict") is True, f"strict must be True; got {schema_wrapper!r}"
+        assert body.get("think") is True, f"think must be True; got {body.get('think')!r}"
 
     def test_when_action_requested_then_schema_constrains_action_index_property(
         self, monkeypatch
     ) -> None:
-        """The json_schema must define an 'action_index' property."""
+        """The `format` schema must define an 'action_index' property."""
         captured = self._call_with_capture(monkeypatch)
         body = captured["kwargs"].get("json", {})
-        schema = body.get("response_format", {}).get("json_schema", {}).get("schema", {})
+        schema = body.get("format", {})
         assert "action_index" in schema.get("properties", {}), (
             f"Schema must declare 'action_index'; got {schema!r}"
         )
@@ -233,9 +231,7 @@ class TestOllamaCredentials:
             captured["headers"] = kwargs.get("headers", {})
             resp = MagicMock()
             resp.status_code = 200
-            resp.json.return_value = {
-                "choices": [{"message": {"content": json.dumps({"action_index": 0})}}]
-            }
+            resp.json.return_value = {"message": {"content": json.dumps({"action_index": 0})}}
             resp.raise_for_status = MagicMock(return_value=None)
             return resp
 

--- a/tests/test_ac62.py
+++ b/tests/test_ac62.py
@@ -21,7 +21,7 @@ Criteria covered (oracle-verified as UNIT or T2):
          with its seed and config file path
 
 Criteria already covered by test_ac60.py / test_ac61.py (omitted here to avoid
-duplication): Ollama /chat/completions contract, LLM output is index, render_action_prompt,
+duplication): Ollama native /api/chat contract, LLM output is index, render_action_prompt,
 .env.example credential files, basic checkpoint save/load.
 """
 
@@ -74,9 +74,7 @@ def _skip_action() -> dict:
 def _fake_ollama_response(action_index: int = 0) -> MagicMock:
     resp = MagicMock()
     resp.status_code = 200
-    resp.json.return_value = {
-        "choices": [{"message": {"content": json.dumps({"action_index": action_index})}}]
-    }
+    resp.json.return_value = {"message": {"content": json.dumps({"action_index": action_index})}}
     resp.raise_for_status = MagicMock(return_value=None)
     return resp
 

--- a/tests/test_board_global.py
+++ b/tests/test_board_global.py
@@ -1,8 +1,8 @@
 """Tests for global acceptance criteria (Issue #48, oracle tier UNIT / T2).
 
 Covered:
-  [T2]   LLM opponent calls Ollama via /chat/completions with
-          json_schema strict output.
+  [T2]   LLM opponent calls Ollama via the native /api/chat endpoint with
+          an enforced JSON-schema `format` field.
   [UNIT] Ollama credentials in .env; .env.example is committed.
   [UNIT] LLM output is an index into legal_actions — always legal.
   [UNIT] render_action_prompt() is the single source of truth for the prompt.
@@ -55,9 +55,7 @@ def _skip() -> dict[str, int]:
 def _make_ollama_response(action_index: int) -> MagicMock:
     resp = MagicMock()
     resp.raise_for_status = MagicMock()
-    resp.json.return_value = {
-        "choices": [{"message": {"content": json.dumps({"action_index": action_index})}}]
-    }
+    resp.json.return_value = {"message": {"content": json.dumps({"action_index": action_index})}}
     return resp
 
 
@@ -147,12 +145,12 @@ def test_when_render_action_prompt_called_with_any_n_actions_then_no_error_is_ra
 
 
 # ---------------------------------------------------------------------------
-# Ollama /chat/completions with json_schema strict
+# Ollama native /api/chat with an enforced `format` schema
 # ---------------------------------------------------------------------------
 
 
-def test_when_ollama_called_then_url_contains_chat_completions():
-    """Criterion: LLM opponent calls Ollama via /chat/completions."""
+def test_when_ollama_called_then_url_targets_api_chat():
+    """Criterion: LLM opponent calls Ollama via the native /api/chat endpoint."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
@@ -162,13 +160,13 @@ def test_when_ollama_called_then_url_contains_chat_completions():
     with patch("httpx.post", side_effect=_fake_post):
         _call_ollama([_skip()])
 
-    assert "/chat/completions" in captured.get("url", ""), (
-        "Request URL must include /chat/completions"
-    )
+    url = captured.get("url", "")
+    assert url.endswith("/api/chat"), "Request URL must target the native /api/chat endpoint"
+    assert "/v1/" not in url, "Native endpoint must not contain /v1/"
 
 
-def test_when_ollama_called_then_response_format_type_is_json_schema():
-    """Criterion: request uses json_schema response_format."""
+def test_when_ollama_called_then_format_type_is_object():
+    """Criterion: request uses an object `format` JSON schema."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
@@ -179,12 +177,12 @@ def test_when_ollama_called_then_response_format_type_is_json_schema():
         _call_ollama([_skip()])
 
     body = captured.get("body", {})
-    assert "response_format" in body
-    assert body["response_format"].get("type") == "json_schema"
+    assert "format" in body
+    assert body["format"].get("type") == "object"
 
 
-def test_when_ollama_called_then_json_schema_strict_is_true():
-    """Criterion: json_schema strict output enforced."""
+def test_when_ollama_called_then_format_schema_requires_action_index():
+    """Criterion: the enforced `format` schema constrains output to 'action_index'."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
@@ -194,12 +192,13 @@ def test_when_ollama_called_then_json_schema_strict_is_true():
     with patch("httpx.post", side_effect=_fake_post):
         _call_ollama([_skip()])
 
-    schema_block = captured["body"].get("response_format", {}).get("json_schema", {})
-    assert schema_block.get("strict") is True
+    fmt = captured["body"].get("format", {})
+    assert "action_index" in fmt.get("required", [])
+    assert fmt.get("properties", {}).get("action_index", {}).get("type") == "integer"
 
 
-def test_when_ollama_called_then_temperature_is_in_request_body():
-    """Criterion: per-call temperature injected into the Ollama request body."""
+def test_when_ollama_called_then_temperature_is_in_request_options():
+    """Criterion: per-call temperature injected into the Ollama request options."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
@@ -209,11 +208,11 @@ def test_when_ollama_called_then_temperature_is_in_request_body():
     with patch("httpx.post", side_effect=_fake_post):
         _call_ollama([_skip()], temperature=0.3)
 
-    assert captured["body"].get("temperature") == pytest.approx(0.3)
+    assert captured["body"].get("options", {}).get("temperature") == pytest.approx(0.3)
 
 
-def test_when_ollama_called_then_top_p_is_in_request_body():
-    """Criterion: per-call top_p injected into the Ollama request body."""
+def test_when_ollama_called_then_top_p_is_in_request_options():
+    """Criterion: per-call top_p injected into the Ollama request options."""
     captured: dict = {}
 
     def _fake_post(url, **kwargs):
@@ -223,7 +222,7 @@ def test_when_ollama_called_then_top_p_is_in_request_body():
     with patch("httpx.post", side_effect=_fake_post):
         _call_ollama([_skip()], top_p=0.95)
 
-    assert captured["body"].get("top_p") == pytest.approx(0.95)
+    assert captured["body"].get("options", {}).get("top_p") == pytest.approx(0.95)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_global_criteria_r4.py
+++ b/tests/test_global_criteria_r4.py
@@ -90,9 +90,7 @@ class TestLLMOutputIsIndex:
         resp = mock.MagicMock()
         resp.status_code = 200
         resp.raise_for_status = mock.MagicMock()
-        resp.json.return_value = {
-            "choices": [{"message": {"content": f'{{"action_index": {action_index}}}'}}]
-        }
+        resp.json.return_value = {"message": {"content": f'{{"action_index": {action_index}}}'}}
         return resp
 
     def _call_with_mocked_http(self, action_index: int, legal_actions: list) -> object:

--- a/tests/test_multi_agent_r4.py
+++ b/tests/test_multi_agent_r4.py
@@ -70,7 +70,7 @@ def _fake_http_response(action_index: int) -> unittest.mock.MagicMock:
     resp = unittest.mock.MagicMock()
     resp.status_code = 200
     resp.json.return_value = {
-        "choices": [{"message": {"content": f'{{"action_index": {action_index}}}'}}]
+        "message": {"content": f'{{"action_index": {action_index}}}'}
     }
     return resp
 
@@ -530,15 +530,16 @@ def test_when_ollama_returns_any_valid_index_then_result_is_always_in_range(
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# Global [T2]: LLM calls /chat/completions with json_schema strict response_format
-# Criterion: LLM opponent calls Ollama via /chat/completions
-#            with json_schema `strict` output
+# Global [T2]: LLM calls the native /api/chat with an enforced `format` schema
+# Criterion: LLM opponent calls Ollama via /api/chat with a JSON-schema `format`
+#            (XGrammar-enforced) rather than the loose /v1 response_format, which
+#            Ollama ignores for reasoning models (ollama#10937, #15260).
 # Black-box: capture httpx.post call args and inspect the outgoing request body.
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-def test_when_ollama_client_is_called_then_url_contains_chat_completions():
-    """URL sent to httpx.post must contain '/chat/completions' (not '/completions')."""
+def test_when_ollama_client_is_called_then_url_is_native_api_chat():
+    """URL sent to httpx.post must be the native /api/chat endpoint, not /v1."""
     from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
@@ -550,13 +551,14 @@ def test_when_ollama_client_is_called_then_url_contains_chat_completions():
 
     call_args = mock_post.call_args
     url = call_args.args[0] if call_args.args else call_args.kwargs.get("url", "")
-    assert "chat/completions" in str(url), (
-        f"Expected URL to contain 'chat/completions', got: {url!r}"
+    assert str(url).endswith("/api/chat"), (
+        f"Expected URL to end with '/api/chat', got: {url!r}"
     )
+    assert "/v1/" not in str(url)
 
 
-def test_when_ollama_client_is_called_then_request_body_includes_response_format():
-    """Request body sent to Ollama must include a 'response_format' key."""
+def test_when_ollama_client_is_called_then_request_body_includes_format():
+    """Request body sent to Ollama must include a native 'format' key."""
     from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
@@ -568,13 +570,11 @@ def test_when_ollama_client_is_called_then_request_body_includes_response_format
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
-    assert "response_format" in body, (
-        "Ollama request body must include 'response_format' for json_schema strict output"
-    )
+    assert "format" in body, "Ollama request body must include native 'format' schema"
 
 
-def test_when_ollama_client_is_called_then_response_format_type_is_json_schema():
-    """response_format.type must equal 'json_schema' (not 'json_object' or absent)."""
+def test_when_ollama_client_is_called_then_format_type_is_object():
+    """format.type must equal 'object' (a raw JSON schema, not OpenAI nesting)."""
     from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
@@ -586,14 +586,14 @@ def test_when_ollama_client_is_called_then_response_format_type_is_json_schema()
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
-    rf = body.get("response_format", {})
-    assert rf.get("type") == "json_schema", (
-        f"response_format.type must be 'json_schema', got: {rf.get('type')!r}"
+    fmt = body.get("format", {})
+    assert fmt.get("type") == "object", (
+        f"format.type must be 'object', got: {fmt.get('type')!r}"
     )
 
 
-def test_when_ollama_client_is_called_then_json_schema_strict_is_true():
-    """response_format.json_schema.strict must be True to enforce exact schema output."""
+def test_when_ollama_client_is_called_then_thinking_is_enabled():
+    """Think must be True: think=false breaks `format` enforcement (ollama#15260)."""
     from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
@@ -603,14 +603,12 @@ def test_when_ollama_client_is_called_then_json_schema_strict_is_true():
     ):
         call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
-    call_args = mock_post.call_args
-    body = call_args.kwargs.get("json") or {}
-    json_schema_def = body.get("response_format", {}).get("json_schema", {})
-    assert json_schema_def.get("strict") is True, "response_format.json_schema.strict must be True"
+    body = mock_post.call_args.kwargs.get("json") or {}
+    assert body.get("think") is True, "thinking must stay enabled for format masking"
 
 
 def test_when_ollama_client_is_called_then_schema_enforces_action_index_field():
-    """json_schema properties must include 'action_index' so the LLM picks an index."""
+    """Format properties must include 'action_index' so the LLM picks an index."""
     from src.agents.ollama_client import call_ollama_for_action_index
 
     legal = [_SKIP_ACTION]
@@ -622,11 +620,9 @@ def test_when_ollama_client_is_called_then_schema_enforces_action_index_field():
 
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
-    schema_def = body.get("response_format", {}).get("json_schema", {})
-    schema = schema_def.get("schema", schema_def)
-    properties = schema.get("properties", {})
+    properties = body.get("format", {}).get("properties", {})
     assert "action_index" in properties, (
-        "json_schema must declare 'action_index' as a required property"
+        "format schema must declare 'action_index' as a required property"
     )
 
 
@@ -634,12 +630,12 @@ def test_when_ollama_client_is_called_then_schema_enforces_action_index_field():
 
 
 @given(st.integers(min_value=1, max_value=10))
-def test_when_ollama_is_called_with_any_n_actions_then_response_format_is_json_schema(
+def test_when_ollama_is_called_with_any_n_actions_then_format_type_is_object(
     n_actions: int,
 ) -> None:
-    """response_format.type is always 'json_schema' regardless of legal_actions size.
+    """format.type is always 'object' regardless of legal_actions size.
 
-    Derived from: 'calls Ollama via /chat/completions with json_schema strict output'.
+    Derived from: 'calls Ollama via /api/chat with an enforced JSON-schema format'.
     """
     from src.agents.ollama_client import call_ollama_for_action_index
 
@@ -651,4 +647,4 @@ def test_when_ollama_is_called_with_any_n_actions_then_response_format_is_json_s
         call_ollama_for_action_index(_obs(), legal, model="gpt-oss:120b")
 
     body = mock_post.call_args.kwargs.get("json") or {}
-    assert body.get("response_format", {}).get("type") == "json_schema"
+    assert body.get("format", {}).get("type") == "object"

--- a/tests/test_multi_agent_r4.py
+++ b/tests/test_multi_agent_r4.py
@@ -69,9 +69,7 @@ def _game_result(**kw):
 def _fake_http_response(action_index: int) -> unittest.mock.MagicMock:
     resp = unittest.mock.MagicMock()
     resp.status_code = 200
-    resp.json.return_value = {
-        "message": {"content": f'{{"action_index": {action_index}}}'}
-    }
+    resp.json.return_value = {"message": {"content": f'{{"action_index": {action_index}}}'}}
     return resp
 
 
@@ -551,9 +549,7 @@ def test_when_ollama_client_is_called_then_url_is_native_api_chat():
 
     call_args = mock_post.call_args
     url = call_args.args[0] if call_args.args else call_args.kwargs.get("url", "")
-    assert str(url).endswith("/api/chat"), (
-        f"Expected URL to end with '/api/chat', got: {url!r}"
-    )
+    assert str(url).endswith("/api/chat"), f"Expected URL to end with '/api/chat', got: {url!r}"
     assert "/v1/" not in str(url)
 
 
@@ -587,9 +583,7 @@ def test_when_ollama_client_is_called_then_format_type_is_object():
     call_args = mock_post.call_args
     body = call_args.kwargs.get("json") or {}
     fmt = body.get("format", {})
-    assert fmt.get("type") == "object", (
-        f"format.type must be 'object', got: {fmt.get('type')!r}"
-    )
+    assert fmt.get("type") == "object", f"format.type must be 'object', got: {fmt.get('type')!r}"
 
 
 def test_when_ollama_client_is_called_then_thinking_is_enabled():

--- a/tests/test_ollama_acceptance.py
+++ b/tests/test_ollama_acceptance.py
@@ -53,9 +53,7 @@ def _cfg(**overrides) -> PlayerConfig:
 def _ok_response(idx: int = 0) -> MagicMock:
     resp = MagicMock()
     resp.raise_for_status.return_value = None
-    resp.json.return_value = {
-        "choices": [{"message": {"content": json.dumps({"action_index": idx})}}]
-    }
+    resp.json.return_value = {"message": {"content": json.dumps({"action_index": idx})}}
     return resp
 
 
@@ -70,14 +68,14 @@ def env_data():
 
 
 # ---------------------------------------------------------------------------
-# 1. json_schema strict
-#    Criterion: LLM opponent calls Ollama via /chat/completions with
-#               json_schema strict output.
+# 1. Enforced `format` schema
+#    Criterion: LLM opponent calls Ollama via the native /api/chat endpoint
+#               with an enforced JSON-schema `format` field and thinking on.
 # ---------------------------------------------------------------------------
 
 
-def test_when_choose_action_called_then_request_uses_json_schema_strict():
-    """Ollama request body must declare response_format.type='json_schema' with strict=True."""
+def test_when_choose_action_called_then_request_uses_enforced_format_schema():
+    """Ollama request body must declare an object `format` schema with thinking enabled."""
     with (
         patch.dict(os.environ, _CREDS, clear=False),
         patch("src.agents.ollama_client.ensure_env_loaded"),
@@ -89,9 +87,10 @@ def test_when_choose_action_called_then_request_uses_json_schema_strict():
         )
 
     body = mock_post.call_args.kwargs["json"]
-    rf = body.get("response_format", {})
-    assert rf.get("type") == "json_schema"
-    assert rf.get("json_schema", {}).get("strict") is True
+    fmt = body.get("format", {})
+    assert fmt.get("type") == "object"
+    assert fmt.get("properties", {}).get("action_index", {}).get("type") == "integer"
+    assert body.get("think") is True
 
 
 # ---------------------------------------------------------------------------
@@ -113,8 +112,8 @@ def test_when_choose_action_called_then_temperature_and_top_p_are_in_request_bod
         )
 
     body = mock_post.call_args.kwargs["json"]
-    assert body["temperature"] == pytest.approx(0.3)
-    assert body["top_p"] == pytest.approx(0.85)
+    assert body["options"]["temperature"] == pytest.approx(0.3)
+    assert body["options"]["top_p"] == pytest.approx(0.85)
 
 
 @given(
@@ -141,8 +140,8 @@ def test_when_any_valid_temperature_and_top_p_then_both_reach_request_body(
         )
 
     body = mock_post.call_args.kwargs["json"]
-    assert body["temperature"] == pytest.approx(temperature, abs=1e-9)
-    assert body["top_p"] == pytest.approx(top_p, abs=1e-9)
+    assert body["options"]["temperature"] == pytest.approx(temperature, abs=1e-9)
+    assert body["options"]["top_p"] == pytest.approx(top_p, abs=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -254,8 +253,8 @@ def test_when_credentials_not_configured_then_defaults_are_used_and_no_error_rai
 
     assert result == 0
     url = mock_post.call_args.args[0]
-    assert url.startswith("http://localhost:11434/v1"), (
-        f"Expected localhost default URL, got: {url!r}"
+    assert url == "http://localhost:11434/api/chat", (
+        f"Expected native localhost default URL, got: {url!r}"
     )
     headers = mock_post.call_args.kwargs["headers"]
     assert headers.get("Authorization") == "Bearer ollama", (
@@ -264,13 +263,13 @@ def test_when_credentials_not_configured_then_defaults_are_used_and_no_error_rai
 
 
 # ---------------------------------------------------------------------------
-# 9. URL ends /chat/completions with Authorization: Bearer header
+# 9. URL ends /api/chat with Authorization: Bearer header
 #    Criterion: URL format + Authorization: Bearer header (no api-version, no api-key).
 # ---------------------------------------------------------------------------
 
 
-def test_when_request_sent_url_contains_chat_completions_and_bearer_auth_header():
-    """POST URL must contain /chat/completions; Authorization: Bearer header required."""
+def test_when_request_sent_url_targets_api_chat_and_bearer_auth_header():
+    """POST URL must target the native /api/chat; Authorization: Bearer header required."""
     with (
         patch.dict(os.environ, _CREDS, clear=False),
         patch("src.agents.ollama_client.ensure_env_loaded"),
@@ -283,7 +282,8 @@ def test_when_request_sent_url_contains_chat_completions_and_bearer_auth_header(
 
     url: str = mock_post.call_args.args[0]
     headers: dict = mock_post.call_args.kwargs["headers"]
-    assert "/chat/completions" in url, f"URL {url!r} missing '/chat/completions'"
+    assert url.endswith("/api/chat"), f"URL {url!r} must end with '/api/chat'"
+    assert "/v1/" not in url, f"URL {url!r} must NOT contain '/v1/'"
     assert "api-version=" not in url, f"URL {url!r} must NOT contain 'api-version='"
     assert "Authorization" in headers, f"'Authorization' header missing; got: {list(headers)}"
     assert headers["Authorization"].startswith("Bearer "), (

--- a/tests/test_ollama_api_contract.py
+++ b/tests/test_ollama_api_contract.py
@@ -1,8 +1,8 @@
 """Spec-derived tests for issue #58 — Ollama API contract and render_action_prompt.
 
 Criteria covered:
-  [T2]   LLM opponent calls Ollama via /chat/completions
-         with json_schema strict output
+  [T2]   LLM opponent calls Ollama via the native /api/chat endpoint
+         with an enforced JSON-schema `format` field
   [UNIT] Ollama credentials load from a git-ignored .env
          (OLLAMA_BASE_URL / OLLAMA_API_KEY); .env.example committed
   [UNIT] LLM output is an index into legal_actions — chosen action always legal
@@ -62,7 +62,7 @@ def _skip_action() -> dict[str, int]:
 
 def _make_mock_response(action_index: int) -> MagicMock:
     """Build a mock httpx.Response for a given action_index reply."""
-    body = {"choices": [{"message": {"content": json.dumps({"action_index": action_index})}}]}
+    body = {"message": {"content": json.dumps({"action_index": action_index})}}
     resp = MagicMock()
     resp.json.return_value = body
     resp.raise_for_status = MagicMock()
@@ -106,23 +106,24 @@ def _call_ollama(
 
 
 # ────────────────────────────────────────────────────────────────────────────
-# Endpoint contract — POST /chat/completions
+# Endpoint contract — POST /api/chat (native Ollama endpoint)
 # ────────────────────────────────────────────────────────────────────────────
 
 
 class TestOllamaChatCompletionsEndpoint:
-    """Ollama /chat/completions endpoint and json_schema strict contract."""
+    """Ollama native /api/chat endpoint and enforced `format`-schema contract."""
 
     def test_when_ollama_called_then_exactly_one_http_request_is_made(self):
         """Criterion: the client makes exactly one call per move."""
         _, calls = _call_ollama([_skip_action()])
         assert len(calls) == 1
 
-    def test_when_ollama_called_then_request_url_contains_chat_completions(self):
-        """Criterion: LLM opponent calls Ollama via /chat/completions."""
+    def test_when_ollama_called_then_request_url_targets_api_chat(self):
+        """Criterion: LLM opponent calls Ollama via the native /api/chat endpoint."""
         _, calls = _call_ollama([_skip_action()])
         url = calls[0]["url"]
-        assert "/chat/completions" in url, f"Expected /chat/completions in URL, got: {url}"
+        assert url.endswith("/api/chat"), f"Expected URL to end with /api/chat, got: {url}"
+        assert "/v1/" not in url, f"Native endpoint must not contain /v1/, got: {url}"
 
     def test_when_ollama_called_then_request_url_does_not_contain_api_version(self):
         """Criterion: Ollama URL has no api-version query parameter."""
@@ -130,44 +131,40 @@ class TestOllamaChatCompletionsEndpoint:
         url = calls[0]["url"]
         assert "api-version=" not in url, f"URL must not contain api-version, got: {url}"
 
-    def test_when_ollama_called_then_request_body_uses_json_schema_response_format(self):
-        """Criterion: response_format type must be 'json_schema'."""
+    def test_when_ollama_called_then_request_body_uses_object_format_schema(self):
+        """Criterion: the native `format` field must be a raw object JSON schema."""
         _, calls = _call_ollama([_skip_action(), _skip_action()])
         body = calls[0]["kwargs"]["json"]
-        rf = body.get("response_format", {})
-        assert rf.get("type") == "json_schema", (
-            f"response_format.type must be 'json_schema', got: {rf}"
-        )
+        fmt = body.get("format", {})
+        assert fmt.get("type") == "object", f"format.type must be 'object', got: {fmt}"
 
-    def test_when_ollama_called_then_json_schema_strict_is_true(self):
-        """Criterion: json_schema strict must be True (enforces output shape)."""
+    def test_when_ollama_called_then_thinking_is_enabled(self):
+        """Criterion: thinking must be enabled so the `format` mask is actually applied."""
         _, calls = _call_ollama([_skip_action()])
         body = calls[0]["kwargs"]["json"]
-        rf = body.get("response_format", {})
-        inner = rf.get("json_schema", {})
-        assert inner.get("strict") is True, f"json_schema.strict must be True, got: {inner}"
+        assert body.get("think") is True, f"think must be True, got: {body.get('think')}"
 
     def test_when_ollama_called_then_request_body_contains_action_index_schema(self):
-        """The json_schema must constrain the output to contain 'action_index'."""
+        """The `format` schema must constrain the output to contain 'action_index'."""
         _, calls = _call_ollama([_skip_action()])
         body = calls[0]["kwargs"]["json"]
         raw_schema = json.dumps(body)
         assert "action_index" in raw_schema, "The request schema must reference 'action_index'"
 
-    def test_when_temperature_supplied_then_it_appears_in_request_body(self):
-        """Criterion: per-call temperature injected into the Ollama request body."""
+    def test_when_temperature_supplied_then_it_appears_in_request_options(self):
+        """Criterion: per-call temperature injected into the Ollama request options."""
         _, calls = _call_ollama([_skip_action()], temperature=0.3)
         body = calls[0]["kwargs"]["json"]
-        assert body.get("temperature") == pytest.approx(0.3), (
-            "temperature must be forwarded to the request body"
+        assert body.get("options", {}).get("temperature") == pytest.approx(0.3), (
+            "temperature must be forwarded to the request options"
         )
 
-    def test_when_top_p_supplied_then_it_appears_in_request_body(self):
-        """Criterion: per-call top_p injected into the Ollama request body."""
+    def test_when_top_p_supplied_then_it_appears_in_request_options(self):
+        """Criterion: per-call top_p injected into the Ollama request options."""
         _, calls = _call_ollama([_skip_action()], top_p=0.85)
         body = calls[0]["kwargs"]["json"]
-        assert body.get("top_p") == pytest.approx(0.85), (
-            "top_p must be forwarded to the request body"
+        assert body.get("options", {}).get("top_p") == pytest.approx(0.85), (
+            "top_p must be forwarded to the request options"
         )
 
 
@@ -240,12 +237,18 @@ class TestOllamaCredentialsFromEnv:
         headers = calls[0]["kwargs"].get("headers", {})
         assert "api-key" not in headers, "The api-key header must not be present in Ollama requests"
 
-    def test_when_base_url_env_var_set_then_request_url_starts_with_it(self):
-        """Criterion: OLLAMA_BASE_URL determines the request endpoint."""
+    def test_when_base_url_env_var_set_then_request_url_targets_its_native_root(self):
+        """Criterion: OLLAMA_BASE_URL determines the request endpoint.
+
+        The base ends in /v1 (used for the model-list probe); the native POST
+        strips it and targets ``{root}/api/chat``.
+        """
         base = "http://custom-ollama.local/v1"
         env = {**_FAKE_ENV, "OLLAMA_BASE_URL": base}
         _, calls = _call_ollama([_skip_action()], env=env)
-        assert calls[0]["url"].startswith(base), "Request URL must start with OLLAMA_BASE_URL"
+        assert calls[0]["url"] == "http://custom-ollama.local/api/chat", (
+            "Request URL must be the base's native /api/chat endpoint (base minus /v1)"
+        )
 
     def test_when_no_env_vars_set_then_request_url_defaults_to_localhost(self):
         """Criterion: missing OLLAMA_BASE_URL falls back to localhost without raising."""
@@ -261,8 +264,8 @@ class TestOllamaCredentialsFromEnv:
         ):
             call_ollama_for_action_index(_make_obs(), [_skip_action()], model="gpt-oss:120b")
 
-        assert captured[0]["url"].startswith("http://localhost:11434/v1"), (
-            "Default base URL must be http://localhost:11434/v1"
+        assert captured[0]["url"] == "http://localhost:11434/api/chat", (
+            "Default POST URL must be the native http://localhost:11434/api/chat"
         )
 
     def test_when_no_api_key_env_var_then_authorization_header_is_bearer_ollama(self):

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -4,9 +4,10 @@ Derived exclusively from acceptance criteria; no implementation source was read.
 All HTTP calls and env-loading are mocked. No real .env is read.
 
 Criteria covered:
-- call_ollama_for_action_index() POSTs to {base}/chat/completions with NO api-version query string
+- call_ollama_for_action_index() POSTs to the native {root}/api/chat endpoint
 - Auth uses Authorization: Bearer <key> header (NOT api-key)
-- Request body sets response_format json_schema with strict:true
+- Request body sets the native `format` to the action_index JSON schema, with
+  thinking enabled (think=true) so the schema mask is honoured (ollama#15260)
 - Returns an index in [0, len(legal_actions)) or None on empty/unparseable/out-of-range reply
 - Per-call temperature and top_p injected verbatim; top_p omitted when None
 - When OLLAMA_BASE_URL / OLLAMA_API_KEY are unset, falls back to defaults (localhost + "ollama")
@@ -58,7 +59,7 @@ def _fake_response(content: str | None) -> MagicMock:
     resp = MagicMock()
     resp.raise_for_status.return_value = None
     resp.json.return_value = {
-        "choices": [{"message": {"content": content or ""}}],
+        "message": {"content": content or ""},
     }
     return resp
 
@@ -103,13 +104,19 @@ def _call(
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def test_when_ollama_called_then_posts_to_url_containing_chat_completions():
-    """call_ollama_for_action_index() must POST to a URL containing /chat/completions."""
+def test_when_ollama_called_then_posts_to_native_api_chat_endpoint():
+    """call_ollama_for_action_index() must POST to the native /api/chat endpoint.
+
+    The OpenAI-compat /v1 endpoint only honours `format` as loose JSON mode and
+    ignores the schema for reasoning models (ollama#10937); the native endpoint
+    enforces it via XGrammar.
+    """
     _, mock_post = _call(["a", "b"])
 
     assert mock_post.called
     url = mock_post.call_args.args[0]
-    assert "/chat/completions" in url
+    assert url.endswith("/api/chat")
+    assert "/v1/" not in url
 
 
 def test_when_ollama_called_then_url_does_not_contain_api_version_query_param():
@@ -136,21 +143,23 @@ def test_when_ollama_called_then_no_api_key_header_is_set():
     assert "api-key" not in headers
 
 
-def test_when_ollama_called_then_response_format_type_is_json_schema():
-    """Request body must set response_format.type to 'json_schema'."""
+def test_when_ollama_called_then_format_is_action_index_schema():
+    """Request body must set the native `format` to the action_index JSON schema."""
     _, mock_post = _call(["a", "b"])
 
     body = mock_post.call_args.kwargs.get("json", {})
-    assert body.get("response_format", {}).get("type") == "json_schema"
+    fmt = body.get("format", {})
+    assert fmt.get("type") == "object"
+    assert fmt.get("properties", {}).get("action_index", {}).get("type") == "integer"
+    assert "action_index" in fmt.get("required", [])
 
 
-def test_when_ollama_called_then_json_schema_strict_is_true():
-    """Request body must set response_format.json_schema.strict to True."""
+def test_when_ollama_called_then_thinking_is_enabled():
+    """Thinking must stay ON: think=false breaks `format` enforcement (ollama#15260)."""
     _, mock_post = _call(["a", "b"])
 
     body = mock_post.call_args.kwargs.get("json", {})
-    schema_obj = body.get("response_format", {}).get("json_schema", {})
-    assert schema_obj.get("strict") is True
+    assert body.get("think") is True
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -220,27 +229,27 @@ def test_when_response_content_lacks_action_index_field_then_none_is_returned():
 
 
 def test_when_temperature_provided_then_it_appears_in_request_body():
-    """Temperature must be injected verbatim into the POST body."""
+    """Temperature must be injected verbatim into the native `options` block."""
     _, mock_post = _call(["a"], temperature=0.3, resp=_resp(0))
 
     body = mock_post.call_args.kwargs.get("json", {})
-    assert body.get("temperature") == pytest.approx(0.3)
+    assert body.get("options", {}).get("temperature") == pytest.approx(0.3)
 
 
 def test_when_top_p_provided_then_it_appears_in_request_body():
-    """top_p must be injected verbatim into the POST body."""
+    """top_p must be injected verbatim into the native `options` block."""
     _, mock_post = _call(["a"], top_p=0.85, resp=_resp(0))
 
     body = mock_post.call_args.kwargs.get("json", {})
-    assert body.get("top_p") == pytest.approx(0.85)
+    assert body.get("options", {}).get("top_p") == pytest.approx(0.85)
 
 
 def test_when_top_p_is_none_then_top_p_key_is_absent_from_body():
-    """When top_p=None, the 'top_p' key must not appear in the POST body."""
+    """When top_p=None, the 'top_p' key must not appear in the `options` block."""
     _, mock_post = _call(["a"], top_p=None, resp=_resp(0))
 
     body = mock_post.call_args.kwargs.get("json", {})
-    assert "top_p" not in body
+    assert "top_p" not in body.get("options", {})
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -262,8 +271,8 @@ def test_when_base_url_env_var_missing_then_defaults_to_localhost():
         )
 
     url = mock_post.call_args.args[0]
-    assert url.startswith("http://localhost:11434/v1"), (
-        f"Expected localhost fallback URL, got: {url!r}"
+    assert url == "http://localhost:11434/api/chat", (
+        f"Expected localhost native /api/chat fallback URL, got: {url!r}"
     )
 
 
@@ -335,7 +344,9 @@ def test_when_any_valid_temperature_given_then_it_appears_verbatim_in_body(tempe
         )
 
     body = mock_post.call_args.kwargs.get("json", {})
-    assert body.get("temperature") == pytest.approx(temperature, rel=1e-6, abs=1e-9)
+    assert body.get("options", {}).get("temperature") == pytest.approx(
+        temperature, rel=1e-6, abs=1e-9
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -352,6 +363,19 @@ class TestExtractActionIndex:
         from src.agents.ollama_client import _extract_action_index
 
         assert _extract_action_index('{"action_index": 7}') == 7
+
+    def test_when_bare_integer_then_index_is_extracted(self):
+        """Cloud models flatten the single-property schema to a bare int."""
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index("0") == 0
+        assert _extract_action_index("  42 ") == 42
+
+    def test_when_bare_boolean_then_returns_none(self):
+        """`true`/`false` are valid JSON ints-ish but must NOT parse as an index."""
+        from src.agents.ollama_client import _extract_action_index
+
+        assert _extract_action_index("true") is None
 
     def test_when_json_fenced_with_lang_tag_then_index_is_extracted(self):
         from src.agents.ollama_client import _extract_action_index

--- a/tests/test_self_play_smoke.py
+++ b/tests/test_self_play_smoke.py
@@ -75,9 +75,7 @@ def _minimal_action() -> dict:
 def _fake_ollama_response(index: int = 0) -> MagicMock:
     resp = MagicMock()
     resp.status_code = 200
-    resp.json.return_value = {
-        "message": {"content": json.dumps({"action_index": index})}
-    }
+    resp.json.return_value = {"message": {"content": json.dumps({"action_index": index})}}
     resp.raise_for_status = MagicMock(return_value=None)
     return resp
 

--- a/tests/test_self_play_smoke.py
+++ b/tests/test_self_play_smoke.py
@@ -76,7 +76,7 @@ def _fake_ollama_response(index: int = 0) -> MagicMock:
     resp = MagicMock()
     resp.status_code = 200
     resp.json.return_value = {
-        "choices": [{"message": {"content": json.dumps({"action_index": index})}}]
+        "message": {"content": json.dumps({"action_index": index})}
     }
     resp.raise_for_status = MagicMock(return_value=None)
     return resp


### PR DESCRIPTION
## Problem

Training against `glm-5.1:cloud` kept falling back to `RandomAgent`. Logs showed glm reasoning for thousands of tokens in prose and getting truncated before emitting any `{"action_index": N}` — i.e. the schema was never enforced.

**Root cause (researched):** Ollama's OpenAI-compatible `/v1/chat/completions` only honours `response_format` as loose *JSON mode* and silently ignores the `json_schema` for many models — Ollama [#10937](https://github.com/ollama/ollama/issues/10937), [#10001](https://github.com/ollama/ollama/issues/10001). The reply is unconstrained, so reasoning models ramble.

## Fix

Switch to Ollama's **native `/api/chat`**, whose `format` field is enforced via XGrammar constrained decoding ([docs](https://docs.ollama.com/capabilities/structured-outputs)):

- POST `{root}/api/chat` (strip the `/v1` kept for the model-list probe).
- Send the raw action_index JSON schema as `format` (not the ignored OpenAI `response_format`).
- Move `temperature`/`top_p`/`num_predict` into the native `options` block; add `stream:false`.
- Keep thinking **enabled** (`think:true`). Ollama defers the `format` mask until the end-of-thinking token; `think=false` closes the thinking tags without it, so the mask never applies ([#15260](https://github.com/ollama/ollama/issues/15260)).
- Parse the native shape (`message.content`/`message.thinking`, `eval_count`, `done_reason`).
- `_extract_action_index` now also accepts a **bare integer** (`"0"`) — cloud-proxied models flatten the single-property schema to a scalar. Bools rejected.

## Verification

Live against `glm-5.1:cloud`:

| | before | after |
|--|--------|-------|
| output | multi-thousand-token prose, truncated | clean structured reply |
| eval_count | hit num_predict cap | **276** |
| latency | 41–58s then empty | **~18s**, `done_reason=stop` |

Full client + real env (21 legal actions) → `PARSED INDEX: 11 | valid: True`.

Tests migrated from the old OpenAI-compat contract to the native `/api/chat` contract (endpoint, `format` schema, `think:true`, `options` block, native response shape) + new bare-int / bool extractor cases. 131 LLM-related tests + ruff green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)