### PR TITLE
feat(train): persist rollout buffer in checkpoints + save every game

### DIFF
--- a/config/llm_6p.yaml
+++ b/config/llm_6p.yaml
@@ -4,7 +4,9 @@
 
 total_timesteps: 1000000
 n_envs: 1
-save_freq: 50
+# Slow LLM games: checkpoint after every completed game so a crash loses at
+# most one in-progress game (was 50 — weeks of unsaved play at hours/game).
+save_freq: 1
 eval_freq: 50
 seed: 42
 device: auto

--- a/src/models/replay_buffer.py
+++ b/src/models/replay_buffer.py
@@ -163,6 +163,42 @@ class RolloutBuffer:
         self.advantages = None
         self.returns = None
 
+    def state_dict(self) -> dict:
+        """Serialize stored transitions for checkpointing.
+
+        Only the raw transitions are persisted; ``advantages`` / ``returns``
+        are transient (recomputed by ``compute_advantages`` immediately before
+        each update) so they are intentionally omitted. Action tensors are
+        moved to CPU for device-independent reload.
+        """
+        return {
+            "observations": list(self.observations),
+            "actions": [{k: v.detach().cpu() for k, v in a.items()} for a in self.actions],
+            "rewards": list(self.rewards),
+            "dones": list(self.dones),
+            "values": list(self.values),
+            "log_probs": list(self.log_probs),
+            "legal_actions": list(self.legal_actions),
+        }
+
+    def load_state_dict(self, state: dict, device: str | None = None) -> None:
+        """Restore transitions saved by :meth:`state_dict`.
+
+        Args:
+            state: Payload produced by :meth:`state_dict`.
+            device: Target device for action tensors; defaults to ``self.device``.
+        """
+        dev = device or self.device
+        self.observations = list(state["observations"])
+        self.actions = [{k: v.to(dev) for k, v in a.items()} for a in state["actions"]]
+        self.rewards = list(state["rewards"])
+        self.dones = list(state["dones"])
+        self.values = list(state["values"])
+        self.log_probs = list(state["log_probs"])
+        self.legal_actions = list(state["legal_actions"])
+        self.advantages = None
+        self.returns = None
+
 
 def _build_mask_tensor(
     legal_actions: list[dict[str, int]],

--- a/training/self_play.py
+++ b/training/self_play.py
@@ -104,6 +104,7 @@ class SelfPlayTrainer:
         self._logger = TensorBoardLogger(self._log_dir)
         self._episode = 0
         self._best_metric_value = 0.0
+        self._buffer: RolloutBuffer | None = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -111,6 +112,7 @@ class SelfPlayTrainer:
 
     def train(self) -> None:
         """Run the self-play training loop."""
+        self._buffer = self._make_buffer()
         self._maybe_resume()
         self._log_seed()
         if self._llm_opponents:
@@ -126,7 +128,7 @@ class SelfPlayTrainer:
             self._device,
             mode,
         )
-        buffer = self._make_buffer()
+        buffer = self._buffer
         last_result: GameResult | None = None
         pbar = tqdm(
             total=self._cfg.total_timesteps,
@@ -177,6 +179,8 @@ class SelfPlayTrainer:
             "opponent_state": self._opponent_net.state_dict(),
             "best_metric_value": self._best_metric_value,
         }
+        if self._buffer is not None:
+            payload["buffer_state"] = self._buffer.state_dict()
         torch.save(payload, path)
 
     def load_checkpoint(self, path: Path) -> None:
@@ -188,6 +192,9 @@ class SelfPlayTrainer:
         self._episode = payload.get("episode", 0)
         self._best_metric_value = payload.get("best_metric_value", 0.0)
         self._restore_rng(payload.get("rng_state", {}))
+        buffer_state = payload.get("buffer_state")
+        if buffer_state is not None and self._buffer is not None:
+            self._buffer.load_state_dict(buffer_state, device=self._device)
 
     # ------------------------------------------------------------------
     # Construction


### PR DESCRIPTION
## Why

Training against the Ollama LLM opponent (`glm-5.1:cloud`) produces **slow games** — hours each. Under the old setup a crash mid-run lost everything:

- Checkpoints fired every `save_freq=50` episodes → at hours/game that's **weeks** of unsaved play between saves.
- The `RolloutBuffer` was never persisted → a crash threw away all transitions accumulated toward the next PPO update (which needs `n_steps=2048`, i.e. many slow games).

## What

- **`RolloutBuffer.state_dict()` / `load_state_dict()`** — serialize raw transitions (observations, actions, rewards, dones, values, log_probs, legal_actions). `advantages`/`returns` are intentionally omitted; they're recomputed by `compute_advantages()` right before each update. Action tensors round-trip via CPU for device independence.
- **`SelfPlayTrainer`** — buffer is now an instance attribute, created **before** `_maybe_resume()`, written into the checkpoint payload, and restored on load. Backward-compatible: checkpoints without `buffer_state` resume with an empty buffer (no crash).
- **`config/llm_6p.yaml`** — `save_freq: 50 → 1`. Every completed game is now durable; a crash loses at most one in-progress game plus its partial buffer.

## Verification

- Save → load roundtrip restores buffer length, rewards, legal_actions, episode counter, best_metric. ✓
- Old checkpoint (no `buffer_state`) resumes cleanly with empty buffer. ✓
- `ruff check` clean on changed files. ✓
- Affected tests (replay/buffer/self_play/checkpoint) pass. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)