### PR TITLE
feat(train): plateau early stopping on win-rate vs a fixed baseline

### DIFF
--- a/config/llm_6p.yaml
+++ b/config/llm_6p.yaml
@@ -46,3 +46,16 @@ reward:
   dense_army_ratio: 0.005
   dense_elimination_bonus: 0.1
   invalid_action_penalty: -0.01
+
+# Early stopping on win-rate vs a fixed RandomAgent baseline (not the gemma
+# opponents — that signal is circular and ~0 for a long time in 6p). Eval games
+# use random seats only, so a check costs no LLM calls. Smoothed over a window;
+# stop after `patience` checks with no `> min_delta` gain; keep the best.pt.
+early_stop:
+  enabled: true
+  eval_every: 20      # episodes between baseline evals (~hours apart, glm-bound)
+  eval_games: 20      # random-vs-learner games per eval (cheap, no LLM)
+  window: 5           # moving-average window (smooths noisy win-rate)
+  patience: 10        # evals with no improvement before stopping
+  min_delta: 0.01     # smallest smoothed win-rate gain that counts
+  restore_best: true  # reload best.pt when stopping

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,7 @@ __all__ = [
     "PPOConfig",
     "NetworkConfig",
     "SelfPlayConfig",
+    "EarlyStopConfig",
     "TrainingConfig",
     "load_config",
     "merge_cli_overrides",
@@ -67,6 +68,29 @@ class SelfPlayConfig:
 
 
 @dataclass(frozen=True)
+class EarlyStopConfig:
+    """Early stopping on a fixed-baseline metric (win-rate vs ``RandomAgent``).
+
+    Research-backed for self-play / sparse-reward training: evaluate against a
+    FIXED reference rather than the (changing, circular) training opponent,
+    smooth the noisy win-rate over a window, and stop after ``patience`` checks
+    with no ``> min_delta`` improvement — keeping the best checkpoint, since
+    over-training self-play agents tends to degrade past the peak.
+
+    Disabled by default; opt in via config. ``eval_games`` use ``RandomAgent``
+    seats only, so a check costs no LLM calls.
+    """
+
+    enabled: bool = False
+    eval_every: int = 50  # episodes between baseline evaluations
+    eval_games: int = 20  # games per baseline evaluation
+    window: int = 5  # moving-average window over evaluations (smooths noise)
+    patience: int = 12  # evaluations without improvement before stopping
+    min_delta: float = 0.01  # smallest smoothed gain that counts as improvement
+    restore_best: bool = True  # reload the best checkpoint when stopping
+
+
+@dataclass(frozen=True)
 class TrainingConfig:
     """Root configuration bundling PPO, network, training, and self-play settings."""
 
@@ -82,6 +106,7 @@ class TrainingConfig:
     network: NetworkConfig = field(default_factory=NetworkConfig)
     reward: RewardConfig = field(default_factory=RewardConfig)
     self_play: SelfPlayConfig = field(default_factory=SelfPlayConfig)
+    early_stop: EarlyStopConfig = field(default_factory=EarlyStopConfig)
 
 
 def load_config(path: Path) -> TrainingConfig:

--- a/src/tb_logger.py
+++ b/src/tb_logger.py
@@ -76,6 +76,17 @@ class TensorBoardLogger:
 
         self._writer.flush()
 
+    def log_scalar(self, tag: str, value: float, episode: int) -> None:
+        """Log a single named scalar at *episode* (e.g. early-stop metrics).
+
+        Args:
+            tag: TensorBoard scalar tag, e.g. ``"early_stop/win_rate_vs_random"``.
+            value: Scalar value to record.
+            episode: Current episode number for the x-axis.
+        """
+        self._writer.add_scalar(tag, value, episode)
+        self._writer.flush()
+
     def close(self) -> None:
         """Flush and close the underlying writer."""
         self._writer.close()

--- a/src/utils/safe_torch.py
+++ b/src/utils/safe_torch.py
@@ -21,10 +21,23 @@ _REGISTERED = False
 
 def _config_safe_globals() -> list[Any]:
     """Project config dataclasses stored inside checkpoints."""
-    from src.config import NetworkConfig, PPOConfig, SelfPlayConfig, TrainingConfig
+    from src.config import (
+        EarlyStopConfig,
+        NetworkConfig,
+        PPOConfig,
+        SelfPlayConfig,
+        TrainingConfig,
+    )
     from src.utils.reward_config import RewardConfig
 
-    return [TrainingConfig, PPOConfig, NetworkConfig, SelfPlayConfig, RewardConfig]
+    return [
+        TrainingConfig,
+        PPOConfig,
+        NetworkConfig,
+        SelfPlayConfig,
+        EarlyStopConfig,
+        RewardConfig,
+    ]
 
 
 def _numpy_safe_globals() -> list[Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -297,11 +297,12 @@ class TestModuleExports:
     """Public API surface declared via __all__."""
 
     def test_when_imported_then_all_lists_public_api(self):
-        """__all__ exports the four dataclasses and three functions."""
+        """__all__ exports the five config dataclasses and three functions."""
         assert set(config_module.__all__) == {
             "PPOConfig",
             "NetworkConfig",
             "SelfPlayConfig",
+            "EarlyStopConfig",
             "TrainingConfig",
             "load_config",
             "merge_cli_overrides",

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -1,0 +1,176 @@
+"""Tests for plateau-detection early stopping and its config wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.config import EarlyStopConfig, TrainingConfig, load_config, merge_cli_overrides
+from training.early_stopping import EarlyStopper
+
+# ---------------------------------------------------------------------------
+# EarlyStopper — pure plateau-detection logic
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyStopper:
+    def test_when_first_update_then_is_best_and_does_not_stop(self) -> None:
+        stopper = EarlyStopper(patience=3)
+        assert stopper.update(0.1) is False
+        assert stopper.is_best
+        assert stopper.best_value == pytest.approx(0.1)
+        assert stopper.best_step == 0
+
+    def test_when_monotonic_improvement_then_never_stops(self) -> None:
+        stopper = EarlyStopper(patience=2)
+        for v in [0.1, 0.2, 0.3, 0.4, 0.5]:
+            assert stopper.update(v) is False
+            assert stopper.is_best
+        assert stopper.num_bad_evals == 0
+
+    def test_when_plateau_then_stops_after_exactly_patience(self) -> None:
+        stopper = EarlyStopper(patience=3, min_delta=0.0, window=1)
+        assert stopper.update(0.5) is False  # best
+        # three non-improving evals → stop on the third
+        assert stopper.update(0.5) is False  # bad 1
+        assert stopper.update(0.5) is False  # bad 2
+        assert stopper.update(0.5) is True  # bad 3 → stop
+        assert stopper.should_stop
+        assert stopper.num_bad_evals == 3
+
+    def test_when_improvement_resets_patience(self) -> None:
+        stopper = EarlyStopper(patience=2, min_delta=0.0, window=1)
+        stopper.update(0.5)  # best
+        stopper.update(0.5)  # bad 1
+        assert stopper.num_bad_evals == 1
+        assert stopper.update(0.6) is False  # improves → reset
+        assert stopper.num_bad_evals == 0
+        assert stopper.is_best
+
+    def test_when_gain_below_min_delta_then_counts_as_bad(self) -> None:
+        stopper = EarlyStopper(patience=2, min_delta=0.05, window=1)
+        stopper.update(0.50)  # best
+        # +0.02 < min_delta 0.05 → not an improvement
+        assert stopper.update(0.52) is False
+        assert not stopper.is_best
+        assert stopper.num_bad_evals == 1
+        # +0.10 > min_delta → improvement
+        assert stopper.update(0.62) is False
+        assert stopper.is_best
+
+    def test_when_window_set_then_decision_uses_moving_average(self) -> None:
+        stopper = EarlyStopper(patience=5, min_delta=0.0, window=2)
+        stopper.update(0.0)  # smoothed 0.0  → best
+        stopper.update(1.0)  # smoothed 0.5  → best
+        # raw drops but the 2-window average (1.0+0.9)/2=0.95 still beats 0.5
+        assert stopper.update(0.9) is False
+        assert stopper.is_best
+        assert stopper.best_value == pytest.approx(0.95)
+
+    @pytest.mark.parametrize("bad_kwargs", [{"patience": 0}, {"window": 0}, {"min_delta": -1.0}])
+    def test_when_invalid_args_then_raises(self, bad_kwargs: dict) -> None:
+        kwargs = {"patience": 3, **bad_kwargs}
+        with pytest.raises(ValueError):
+            EarlyStopper(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# EarlyStopConfig — defaults, YAML loading, CLI overrides
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyStopConfig:
+    def test_when_default_then_disabled(self) -> None:
+        cfg = TrainingConfig()
+        assert isinstance(cfg.early_stop, EarlyStopConfig)
+        assert cfg.early_stop.enabled is False
+        assert cfg.early_stop.restore_best is True
+
+    def test_when_yaml_has_early_stop_then_loaded(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(
+            yaml.dump(
+                {
+                    "seed": 1,
+                    "early_stop": {
+                        "enabled": True,
+                        "eval_every": 25,
+                        "patience": 7,
+                        "min_delta": 0.02,
+                        "window": 3,
+                    },
+                }
+            )
+        )
+        cfg = load_config(path)
+        assert cfg.early_stop.enabled is True
+        assert cfg.early_stop.eval_every == 25
+        assert cfg.early_stop.patience == 7
+        assert cfg.early_stop.min_delta == pytest.approx(0.02)
+        assert cfg.early_stop.window == 3
+
+    def test_when_cli_override_then_applies_to_nested_field(self) -> None:
+        cfg = TrainingConfig()
+        merged = merge_cli_overrides(
+            cfg, {"early_stop.enabled": "true", "early_stop.patience": "9"}
+        )
+        assert merged.early_stop.enabled is True
+        assert merged.early_stop.patience == 9
+
+
+# ---------------------------------------------------------------------------
+# Trainer wiring — _maybe_early_stop drives the stop decision (games mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestTrainerEarlyStopWiring:
+    def _make_trainer(self, tmp_path: Path, **es_kwargs):
+        from src.config import SelfPlayConfig
+        from training.self_play import SelfPlayTrainer
+
+        cfg = TrainingConfig(
+            seed=0,
+            self_play=SelfPlayConfig(n_players=2),
+            early_stop=EarlyStopConfig(enabled=True, **es_kwargs),
+        )
+        return SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, log_dir=tmp_path / "tb")
+
+    def test_when_disabled_then_no_stopper(self, tmp_path: Path) -> None:
+        from training.self_play import SelfPlayTrainer
+
+        cfg = TrainingConfig()  # early_stop disabled by default
+        trainer = SelfPlayTrainer(cfg, checkpoint_dir=tmp_path, log_dir=tmp_path / "tb")
+        assert trainer._early_stopper is None
+        assert trainer._maybe_early_stop() is False
+
+    def test_when_plateau_then_stops_and_saves_best(self, tmp_path: Path, monkeypatch) -> None:
+        trainer = self._make_trainer(
+            tmp_path, eval_every=1, patience=3, min_delta=0.0, window=1, restore_best=False
+        )
+        scripted = iter([0.10, 0.20, 0.20, 0.20, 0.20])
+        monkeypatch.setattr(trainer, "_evaluate_against_random", lambda: next(scripted))
+
+        stops = []
+        for ep in range(1, 6):
+            trainer._episode = ep
+            stops.append(trainer._maybe_early_stop())
+
+        # best at the 0.20 eval (ep 2); then 3 flat evals exhaust patience
+        assert stops == [False, False, False, False, True]
+        assert (tmp_path / "best.pt").exists()
+        assert trainer._early_stopper.best_value == pytest.approx(0.20)
+
+    def test_when_off_schedule_then_skips_eval(self, tmp_path: Path, monkeypatch) -> None:
+        trainer = self._make_trainer(tmp_path, eval_every=50, patience=3)
+        called = {"n": 0}
+
+        def _spy() -> float:
+            called["n"] += 1
+            return 0.5
+
+        monkeypatch.setattr(trainer, "_evaluate_against_random", _spy)
+        trainer._episode = 37  # not a multiple of eval_every
+        assert trainer._maybe_early_stop() is False
+        assert called["n"] == 0

--- a/training/early_stopping.py
+++ b/training/early_stopping.py
@@ -1,0 +1,107 @@
+"""Plateau-detection early stopping for self-play training.
+
+A small, pure-logic helper: feed it a monitored metric (win-rate vs a fixed
+baseline) at each evaluation and it reports when the smoothed metric has
+stopped improving for ``patience`` consecutive evaluations.
+
+Design follows the self-play / sparse-reward literature:
+
+* **Smooth before comparing.** RL evaluation metrics are noisy, so the decision
+  is made on a trailing moving average (``window``), not the raw value.
+* **Require a real gain.** Only an improvement greater than ``min_delta`` over
+  the running best resets the patience counter (maximisation).
+* **Track the best.** ``is_best`` flags the evaluation that set a new best so
+  the caller can snapshot a "restore-best" checkpoint, since self-play agents
+  often degrade past their peak.
+"""
+
+from __future__ import annotations
+
+__all__ = ["EarlyStopper"]
+
+
+class EarlyStopper:
+    """Detects a plateau in a maximised, noisy metric.
+
+    Call :meth:`update` once per evaluation with the latest metric value; it
+    returns ``True`` once the smoothed metric has failed to improve by more
+    than ``min_delta`` for ``patience`` consecutive evaluations.
+    """
+
+    def __init__(self, patience: int, min_delta: float = 0.0, window: int = 1) -> None:
+        """Initialise the stopper.
+
+        Args:
+            patience: Evaluations without improvement tolerated before stopping.
+            min_delta: Smallest increase in the smoothed metric counted as an
+                improvement.
+            window: Trailing window size for the moving average; ``1`` disables
+                smoothing.
+        """
+        if patience < 1:
+            raise ValueError("patience must be >= 1")
+        if window < 1:
+            raise ValueError("window must be >= 1")
+        if min_delta < 0:
+            raise ValueError("min_delta must be >= 0")
+        self._patience = patience
+        self._min_delta = min_delta
+        self._window = window
+        self._history: list[float] = []
+        self._best: float = float("-inf")
+        self._best_step: int = -1
+        self._num_bad: int = 0
+        self._is_best: bool = False
+
+    def update(self, value: float) -> bool:
+        """Record an evaluation and report whether training should stop.
+
+        Args:
+            value: The latest raw metric value (higher is better).
+
+        Returns:
+            ``True`` if the smoothed metric has not improved by ``min_delta``
+            for ``patience`` consecutive evaluations.
+        """
+        self._history.append(value)
+        smoothed = self.smoothed_value
+        if smoothed > self._best + self._min_delta:
+            self._best = smoothed
+            self._best_step = len(self._history) - 1
+            self._num_bad = 0
+            self._is_best = True
+        else:
+            self._is_best = False
+            self._num_bad += 1
+        return self.should_stop
+
+    @property
+    def smoothed_value(self) -> float:
+        """Trailing moving average of the last ``window`` recorded values."""
+        recent = self._history[-self._window :]
+        return sum(recent) / len(recent)
+
+    @property
+    def is_best(self) -> bool:
+        """Whether the most recent :meth:`update` set a new smoothed best."""
+        return self._is_best
+
+    @property
+    def best_value(self) -> float:
+        """Best smoothed value seen so far (``-inf`` before any update)."""
+        return self._best
+
+    @property
+    def best_step(self) -> int:
+        """Zero-based index of the evaluation that set the current best."""
+        return self._best_step
+
+    @property
+    def num_bad_evals(self) -> int:
+        """Consecutive evaluations since the last improvement."""
+        return self._num_bad
+
+    @property
+    def should_stop(self) -> bool:
+        """Whether the patience budget is exhausted."""
+        return self._num_bad >= self._patience

--- a/training/self_play.py
+++ b/training/self_play.py
@@ -28,6 +28,7 @@ from src.tb_logger import TensorBoardLogger
 from src.utils.constants import ACTION_DIMS
 from src.utils.log import get_logger
 from src.utils.seed import set_global_seeds
+from training.early_stopping import EarlyStopper
 
 _log = get_logger("train")
 
@@ -104,6 +105,7 @@ class SelfPlayTrainer:
         self._logger = TensorBoardLogger(self._log_dir)
         self._episode = 0
         self._best_metric_value = 0.0
+        self._early_stopper = self._build_early_stopper()
         self._buffer: RolloutBuffer | None = None
 
     # ------------------------------------------------------------------
@@ -148,6 +150,7 @@ class SelfPlayTrainer:
                 updated = True
             self._maybe_evaluate_and_promote()
             self._maybe_checkpoint()
+            stop = self._maybe_early_stop()
             self._episode += 1
             pbar.update(1)
             if updated:
@@ -161,9 +164,12 @@ class SelfPlayTrainer:
                     result.n_turns,
                     result.elimination_order,
                 )
+            if stop:
+                break
         pbar.close()
         if len(buffer) > 0 and last_result is not None:
             self._update_and_log(buffer, last_result)
+        self._maybe_restore_best()
         self._logger.close()
         _log.info("training complete — total episodes=%d", self._episode)
 
@@ -437,6 +443,85 @@ class SelfPlayTrainer:
     def _promote_current_to_opponent(self) -> None:
         self._opponent_net.load_state_dict(self._agent._net.state_dict())
         _log.info("opponent promoted at episode=%d", self._episode)
+
+    # ------------------------------------------------------------------
+    # Early stopping (plateau detection on win-rate vs a fixed baseline)
+    # ------------------------------------------------------------------
+
+    def _build_early_stopper(self) -> EarlyStopper | None:
+        es = self._cfg.early_stop
+        if not es.enabled:
+            return None
+        return EarlyStopper(patience=es.patience, min_delta=es.min_delta, window=es.window)
+
+    def _maybe_early_stop(self) -> bool:
+        """Evaluate vs a fixed baseline on schedule; return True to stop.
+
+        Win-rate against the training opponent is circular and (in 6p) ~0 for a
+        long time, so the plateau signal is win-rate against a fixed
+        ``RandomAgent`` reference — a clean, monotone-ish generalisation curve
+        that costs no LLM calls. The best checkpoint is snapshotted so training
+        can restore the peak (self-play agents tend to degrade past it).
+        """
+        es = self._cfg.early_stop
+        if self._early_stopper is None:
+            return False
+        if self._episode == 0 or self._episode % es.eval_every != 0:
+            return False
+        win_rate = self._evaluate_against_random()
+        stop = self._early_stopper.update(win_rate)
+        self._logger.log_scalar("early_stop/win_rate_vs_random", win_rate, self._episode)
+        self._logger.log_scalar(
+            "early_stop/smoothed_best", self._early_stopper.best_value, self._episode
+        )
+        _log.info(
+            "early-stop eval ep=%d | win_rate_vs_random=%.3f smoothed_best=%.3f bad=%d/%d%s",
+            self._episode,
+            win_rate,
+            self._early_stopper.best_value,
+            self._early_stopper.num_bad_evals,
+            es.patience,
+            " — NEW BEST" if self._early_stopper.is_best else "",
+        )
+        if self._early_stopper.is_best:
+            self.save_checkpoint(self._checkpoint_dir / "best.pt")
+        if stop:
+            _log.info(
+                "early stopping at ep=%d — no win-rate gain in %d evals (best=%.3f)",
+                self._episode,
+                es.patience,
+                self._early_stopper.best_value,
+            )
+        return stop
+
+    def _evaluate_against_random(self) -> float:
+        """Win-rate of the learner (player 0) vs an all-``RandomAgent`` board."""
+        from src.agents.random_agent import RandomAgent
+        from training.evaluate import evaluate_agents
+
+        result = evaluate_agents(
+            self._agent,
+            RandomAgent(seed=self._cfg.seed),
+            n_games=self._cfg.early_stop.eval_games,
+            n_players=self._cfg.self_play.n_players,
+            seed=self._cfg.seed + self._episode,
+            max_turns=self._max_turns,
+        )
+        return result.win_rate_a
+
+    def _maybe_restore_best(self) -> None:
+        """Reload the best checkpoint so the final model is the peak, not the last."""
+        es = self._cfg.early_stop
+        if self._early_stopper is None or not es.restore_best:
+            return
+        best_path = self._checkpoint_dir / "best.pt"
+        if best_path.exists():
+            self.load_checkpoint(best_path)
+            _log.info(
+                "restored best checkpoint from %s (best=%.3f)",
+                best_path,
+                self._early_stopper.best_value,
+            )
 
     # ------------------------------------------------------------------
     # Checkpointing


### PR DESCRIPTION
## Problem

Training has no natural endpoint — `total_timesteps=1M` episodes is ~years at LLM latency, and over-training self-play agents degrades them past the peak. Need principled early stopping.

## Approach (research-backed)

Evaluate against a **fixed `RandomAgent` baseline**, not the training opponent. Win-rate vs the opponent you train on is circular and (in 6p) sits at ~0 for a long time; a fixed reference gives a clean, monotone-ish generalisation curve. Eval games use random seats only — **no LLM calls**.

## What's added

- **`EarlyStopper`** (`training/early_stopping.py`) — pure plateau detector: moving-average smoothing (RL evals are noisy), `min_delta`-gated improvement, `patience` counter, tracks best + `is_best`.
- **`EarlyStopConfig`** — frozen, wired into `TrainingConfig`, registered in the `safe_torch` allowlist; enabled in `config/llm_6p.yaml` (patience=10, window=5, min_delta=0.01, eval_every=20).
- **Trainer wiring** (`training/self_play.py`):
  - `_evaluate_against_random()` — learner vs all-`RandomAgent` board.
  - `_maybe_early_stop()` — on schedule: eval → `stopper.update()` → TB log → save `best.pt` on new best → stop signal.
  - `_maybe_restore_best()` — reload `best.pt` at stop (peak, not last — self-play decays past peak).
- **`tb_logger.log_scalar()`** for the early-stop metrics.

## Tests

15 new (`tests/test_early_stopping.py`): stopper logic (first-best, monotonic, plateau-stops-at-patience, reset, min_delta, window smoothing, arg validation), config (defaults/YAML/CLI override), trainer wiring (disabled→no-op, plateau→stop+saves `best.pt`, off-schedule skip). Fixed 2 collateral tests (`__all__` export, safe-globals round-trip).

`ruff check . tests` ✅ · `pytest -m "not integration"` ✅ (0 failed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)