### PR TITLE
fix(ppo): stabilize PPO updates (advantage norm + k3 KL + target-KL stop)

### DIFF
--- a/config/llm_6p.yaml
+++ b/config/llm_6p.yaml
@@ -15,7 +15,11 @@ device: auto
 max_turns: 2000
 
 ppo:
-  lr: 0.0003
+  # lr lowered 3e-4 -> 1e-4 and n_epochs 10 -> 4: the first updates start from a
+  # sharp BC-warm-started policy over one game's small correlated rollout, which
+  # diverged (approx_kl ~3.2) at the old settings. target_kl bails the epoch loop
+  # the moment the policy drifts too far.
+  lr: 0.0001
   gamma: 0.99
   gae_lambda: 0.95
   clip_epsilon: 0.2
@@ -23,7 +27,8 @@ ppo:
   value_loss_coef: 0.5
   max_grad_norm: 0.5
   n_steps: 2048
-  n_epochs: 10
+  n_epochs: 4
+  target_kl: 0.02   # k3-estimator KL; epoch loop bails at 1.5x (=0.03)
   batch_size: 64
 
 network:

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
-# Direct RL training against glm LLM opponents — no pretraining phase.
+# Direct RL training against cloud LLM opponents — no pretraining phase.
 #
 # Self-detaching: by default the training runs in the background via nohup and
 # survives the terminal closing (no tmux needed). A PID file tracks the run so
 # it can be stopped/inspected later.
 #
 # The learner (slot 0) plays a 6-player game against 5 Ollama-served LLM
-# opponents (default glm-5.1:cloud). Asymmetric opponents → uneven boards →
+# opponents (default gemma4:31b-cloud). Asymmetric opponents → uneven boards →
 # the terminal margin reward + done-flag give the value head real targets, so
 # learning works without a self-play bootstrap (a 2p self-play pretrain is
 # symmetric → 21/21 stalemate → zero terminal signal, so it is skipped).
 # save_freq=1 + rollout-buffer persistence make every game durable and the run
-# crash-resumable. glm is latency-bound: ~hours/game, full training ~days.
+# crash-resumable. Throughput is LLM-latency-bound; gemma4:31b-cloud answers
+# in well under a second, so games run far faster than with glm.
 #
 # Usage:
 #   ./scripts/train.sh                 # start detached (resume latest.pt if present)
@@ -21,10 +22,10 @@
 #   ./scripts/train.sh --stop          # stop the running training
 #
 # Override defaults via env vars:
-#   MODEL=glm-5.1:cloud MAX_TURNS=150 N_STEPS=512 EPISODES=100000 \
+#   MODEL=gemma4:31b-cloud MAX_TURNS=150 N_STEPS=512 EPISODES=100000 \
 #   N_PLAYERS=2 CONFIG=config/llm_6p.yaml ./scripts/train.sh
 #
-# Tip: for faster iteration use N_PLAYERS=2 (learner vs 1 glm) — games resolve
+# Tip: for faster iteration use N_PLAYERS=2 (learner vs 1 LLM) — games resolve
 # (real win/loss) and there is 1 LLM call/turn instead of 5.
 
 set -euo pipefail
@@ -33,7 +34,7 @@ set -euo pipefail
 # Configuration (override via env vars)
 # ------------------------------------------------------------------
 
-MODEL="${MODEL:-glm-5.1:cloud}"          # Ollama model for every LLM opponent
+MODEL="${MODEL:-gemma4:31b-cloud}"       # Ollama model for every LLM opponent
 CONFIG="${CONFIG:-config/llm_6p.yaml}"   # LLM-mode config (llm_profiles_path set)
 MAX_TURNS="${MAX_TURNS:-150}"            # player-turn cap (turns, not env steps)
 N_STEPS="${N_STEPS:-512}"               # PPO rollout size — smaller = more frequent updates
@@ -125,12 +126,12 @@ OVERRIDES=(--override "max_turns=$MAX_TURNS" --override "ppo.n_steps=$N_STEPS")
 [ -n "$N_PLAYERS" ] && OVERRIDES+=(--override "self_play.n_players=$N_PLAYERS")
 
 echo "============================================================"
-echo "  Direct glm training"
+echo "  Direct LLM training"
 echo "  Model:        $MODEL"
 echo "  Config:       $CONFIG"
 echo "  max_turns:    $MAX_TURNS (player-turns)   ppo.n_steps: $N_STEPS"
 echo "  players:      ${N_PLAYERS:-<config default>}   episodes: ${EPISODES:-<config default>}"
-echo "  Expected wall time: ~days (glm latency-bound)"
+echo "  Expected wall time: LLM-latency-bound (fast with gemma4:31b-cloud)"
 echo "============================================================"
 
 # ------------------------------------------------------------------

--- a/src/config.py
+++ b/src/config.py
@@ -88,6 +88,14 @@ class PPOConfig:
     n_steps: int = 2048
     n_epochs: int = 10
     batch_size: int = 64
+    # Stop the epoch loop early once the policy has drifted past this approx-KL
+    # (guards against divergence from many epochs over a small, correlated
+    # buffer — e.g. a BC-warm-started policy). 0.0 disables the guard.
+    target_kl: float = 0.05
+    # Normalize advantages to zero-mean/unit-std per mini-batch (SB3 default).
+    # Essential for stability: raw advantages (terminal-margin + dense + GAE)
+    # otherwise produce unbounded policy-gradient steps (approx_kl ~1).
+    normalize_advantage: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/models/ppo.py
+++ b/src/models/ppo.py
@@ -61,7 +61,11 @@ class PPOTrainer:
             "explained_variance": 0.0,
         }
 
+        target_kl = getattr(self.config, "target_kl", 0.0)
+        epochs_run = 0
         for _epoch in range(self.config.n_epochs):
+            epoch_kl_sum = 0.0
+            epoch_batches = 0
             for batch in buffer.get(
                 batch_size=self.config.batch_size,
                 action_dims=self.net.action_dims,
@@ -69,8 +73,23 @@ class PPOTrainer:
                 batch_metrics = self._update_step(batch)
                 for key in metrics:
                     metrics[key] += batch_metrics[key]
+                epoch_kl_sum += batch_metrics["approx_kl"]
+                epoch_batches += 1
+            epochs_run += 1
+            # Target-KL early stop: abandon the remaining epochs once the policy
+            # has already moved too far this update. Prevents the KL blow-up seen
+            # with a sharp (BC-warm-started) policy run for many epochs over one
+            # game's small, correlated rollout.
+            if target_kl and epoch_batches and (epoch_kl_sum / epoch_batches) > 1.5 * target_kl:
+                _log.info(
+                    "target-KL early stop: epoch=%d approx_kl=%.4f > 1.5*target_kl=%.4f",
+                    epochs_run,
+                    epoch_kl_sum / epoch_batches,
+                    1.5 * target_kl,
+                )
+                break
 
-        n_batches = self.config.n_epochs * self._n_batches(buffer)
+        n_batches = epochs_run * self._n_batches(buffer)
         if n_batches > 0:
             for key in metrics:
                 metrics[key] /= n_batches
@@ -89,6 +108,16 @@ class PPOTrainer:
         actions = batch["actions"]
         old_log_probs = batch["log_probs"]
         advantages = batch["advantages"]
+        # Per-mini-batch advantage normalization (standard PPO; SB3 default).
+        # Without it the policy-gradient magnitude scales with the raw advantage
+        # scale (here: terminal-margin + dense rewards + GAE), making a single
+        # epoch move the policy enormously (observed approx_kl ~1). Normalizing
+        # to zero-mean/unit-std keeps each update inside the trust region. Skip
+        # when the batch advantages are (near-)constant: dividing by ~0 std just
+        # amplifies numerical noise into a huge spurious update.
+        adv_std = advantages.std()
+        if getattr(self.config, "normalize_advantage", True) and adv_std > 1e-6:
+            advantages = (advantages - advantages.mean()) / (adv_std + 1e-8)
         returns = batch["returns"]
         # Apply the same per-head masks used at sampling time so new_log_prob
         # is comparable to the stored old_log_prob.
@@ -145,7 +174,11 @@ class PPOTrainer:
         self.optimizer.step()
 
         with torch.no_grad():
-            approx_kl = ((old_log_probs - new_log_probs).abs()).mean().item()
+            # Schulman k3 estimator (SB3/standard PPO): low-variance, ≥0, and
+            # comparable to published target_kl values. ``ratio`` already equals
+            # exp(new - old), so logratio = new - old.
+            logratio = new_log_probs - old_log_probs
+            approx_kl = ((ratio - 1) - logratio).mean().item()
             clip_fraction = ((ratio - 1).abs() > self.config.clip_epsilon).float().mean().item()
             explained_variance = self._explained_variance(returns, new_values.squeeze(-1))
 

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -151,9 +151,13 @@ class TestUpdate:
         assert "explained_variance" in metrics
 
     def test_policy_loss_is_negative(self):
-        """Policy loss is negative (we maximize clipped surrogate)."""
+        """Policy loss is negative (we maximize clipped surrogate).
+
+        Uses raw advantages: with per-batch advantage normalization (zero-mean)
+        the surrogate is centered near 0 and its sign is no longer an invariant.
+        """
         net = _make_net()
-        cfg = PPOConfig(n_epochs=1, batch_size=4)
+        cfg = PPOConfig(n_epochs=1, batch_size=4, normalize_advantage=False)
         trainer = PPOTrainer(net, cfg)
         buf = RolloutBuffer(capacity=8, device="cpu")
         _fill_buffer_with_obs(buf, net, 8)


### PR DESCRIPTION
## Problem
The first real PPO update from the BC-warm-started policy **diverged**: `approx_kl ≈ 3.2`, `clip ≈ 0.87`. Lowering `n_epochs` (10→4) and `lr` only reduced it to ~1.1 — still destroying the warm-start every update.

## Root cause
Advantages were fed **raw** into the surrogate loss. The policy-gradient magnitude therefore scaled with the raw advantage scale (terminal-margin + dense rewards + GAE), so a *single* epoch moved the policy enormously. The KL metric was also non-standard (`abs().mean()`), inflating the reading.

## Fix
- **Per-mini-batch advantage normalization** (zero-mean/unit-std, SB3 default; `cfg.normalize_advantage`, skipped when std≈0). On real rollouts this drops `approx_kl` from **~1.1 → ~0.0004**.
- **k3 KL estimator** `((ratio−1) − logratio)` — non-negative, low-variance, comparable to published `target_kl` values.
- **target-KL early stop** bails the epoch loop at `1.5 × target_kl`.
- `config/llm_6p.yaml`: `lr 3e-4→1e-4`, `n_epochs 10→4`, `target_kl 0.02` (board-game/control-PPO range — OpenSpiel + the "37 PPO details").
- `train.sh`: default to `gemma4:31b-cloud` (~0.8s/call vs glm's 27–68s).

## Verification
- Smoke (real self-play rollout, this exact code): `approx_kl=0.0004 clip=0.000 policy_loss=-0.0099` — healthy, well under target.
- `pytest tests/test_ppo.py` green; `ruff` clean.
- Full `pytest -m "not integration"` green (one unrelated `test_bc_workflow_docs` failure is local-only — it skips in CI since `models/pretrained.pt` is untracked; it's a pre-existing `ActorCritic(NetworkConfig())` signature bug, separate from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)