### PR TITLE
feat(train): curriculum + progress shaping + KL-ref anchor for from-scratch RL

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -97,6 +97,11 @@ class PPOConfig:
     # Essential for stability: raw advantages (terminal-margin + dense + GAE)
     # otherwise produce unbounded policy-gradient steps (approx_kl ~1).
     normalize_advantage: bool = True
+    # Coefficient for an anchor penalty pulling the policy toward a frozen
+    # reference (the BC clone), RLHF-style. > 0 enables fine-tuning a sharp
+    # BC-warm-started policy without the divergence that plain PPO causes
+    # (the reference is loaded from ``BCConfig.output_path``). 0.0 disables.
+    kl_ref_coef: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -118,6 +123,20 @@ class SelfPlayConfig:
     n_players: int = 2
     llm_profiles_path: str | None = None
     llm_model: str | None = None  # uniform model override for all LLM opponents
+    # Reverse curriculum: seed near-won boards so a from-scratch learner reaches
+    # wins, then anneal difficulty up. Disabled by default.
+    curriculum_enabled: bool = False
+    # "territory": learner owns all but k territories per opponent, k grows.
+    # "army": balanced territories but the learner starts army-rich (multiplier),
+    #         annealed toward 1.0 — teaches converting a material edge into a win,
+    #         which transfers to full games (territory mode tops out near-won).
+    curriculum_mode: str = "territory"
+    curriculum_start: int = 2  # (territory) opponent territories at the easiest stage
+    curriculum_step: int = 2  # (territory) territories added per opponent on promotion
+    curriculum_army_start: float = 4.0  # (army) learner army multiplier at the easiest stage
+    curriculum_army_step: float = 0.5  # (army) multiplier reduction per promotion (toward 1.0)
+    curriculum_promote_threshold: float = 0.7  # learner win-rate to advance a stage
+    curriculum_window: int = 50  # games over which the stage win-rate is measured
 
 
 @dataclass(frozen=True)

--- a/src/env.py
+++ b/src/env.py
@@ -95,6 +95,12 @@ class RisikoEnv(gym.Env):
             else fortify_adjacent_only
         )
         self.state: GameState = GameState()
+        # Optional reverse-curriculum start state: when set to
+        # ``{"advantaged_player": id, "opponent_territories": k}`` the board is
+        # seeded near-won for that player (it owns all but ``k`` territories per
+        # opponent, opponents start with 1 army each). Lets a from-scratch agent
+        # actually reach + experience wins, then the trainer anneals ``k`` up.
+        self.curriculum: dict[str, float] | None = None
         self.observation_space = spaces.Dict(
             {
                 "territory_owner": spaces.Box(0, 5, (NUM_TERRITORIES,), dtype=np.int32),
@@ -207,15 +213,74 @@ class RisikoEnv(gym.Env):
     def _setup_board(self) -> None:
         s = self.state
         s.rng.shuffle(s.deck)
-        order = np.arange(NUM_TERRITORIES)
-        s.rng.shuffle(order)
-        for idx, terr in enumerate(order):
-            player = idx % self.n_players
-            s.territory_owner[terr] = player
-            s.armies[terr] = 1
-        self._place_initial_armies()
+        if self.curriculum is not None:
+            self._setup_curriculum_board()
+        else:
+            order = np.arange(NUM_TERRITORIES)
+            s.rng.shuffle(order)
+            for idx, terr in enumerate(order):
+                player = idx % self.n_players
+                s.territory_owner[terr] = player
+                s.armies[terr] = 1
+            self._place_initial_armies()
         self._compute_reinforcements()
         s.phase = PHASE_TRADE if self._has_tradeable_cards(s.current_player) else PHASE_REINFORCE
+
+    def _setup_curriculum_board(self) -> None:
+        """Seed a near-won board so a weak policy can still reach a win.
+
+        ``advantaged_player`` owns all but ``k`` territories per opponent
+        (opponents start with 1 army each); its extra starting armies are piled
+        onto its land so the lead is real, not just territorial.
+        """
+        s = self.state
+        cur = self.curriculum or {}
+        adv = int(cur.get("advantaged_player", 0))
+        if "army_advantage" in cur:
+            self._setup_army_advantage_board(adv, float(cur["army_advantage"]))
+            return
+        k = max(1, int(cur.get("opponent_territories", 1)))
+        order = np.arange(NUM_TERRITORIES)
+        s.rng.shuffle(order)
+        idx = 0
+        for player in range(self.n_players):
+            if player == adv:
+                continue
+            for _ in range(min(k, NUM_TERRITORIES - idx - 1)):
+                terr = int(order[idx])
+                s.territory_owner[terr] = player
+                s.armies[terr] = 1
+                idx += 1
+        for terr in order[idx:]:
+            s.territory_owner[int(terr)] = adv
+            s.armies[int(terr)] = 1
+        # Pile the advantaged player's remaining starting armies on its land.
+        owned = np.where(s.territory_owner == adv)[0]
+        extra = STARTING_ARMIES[self.n_players] - len(owned)
+        if extra > 0 and len(owned) > 0:
+            for terr in s.rng.choice(owned, size=int(extra), replace=True):
+                s.armies[int(terr)] += 1
+
+    def _setup_army_advantage_board(self, adv: int, multiplier: float) -> None:
+        """Even territory split, learner army-rich (multiplier x normal mass).
+
+        Games stay full-size while the learner has a material edge to convert
+        into a win; the trainer anneals the multiplier toward 1.0 (balanced).
+        """
+        s = self.state
+        order = np.arange(NUM_TERRITORIES)
+        s.rng.shuffle(order)
+        for i, terr in enumerate(order):
+            s.territory_owner[int(terr)] = i % self.n_players
+            s.armies[int(terr)] = 1
+        self._place_initial_armies()
+        # Pile extra armies on the advantaged player to reach ``multiplier`` ×.
+        owned = np.where(s.territory_owner == adv)[0]
+        base = STARTING_ARMIES[self.n_players]
+        extra = int(round((multiplier - 1.0) * base))
+        if extra > 0 and len(owned) > 0:
+            for terr in s.rng.choice(owned, size=extra, replace=True):
+                s.armies[int(terr)] += 1
 
     def _place_initial_armies(self) -> None:
         s = self.state
@@ -644,7 +709,27 @@ class RisikoEnv(gym.Env):
                 continue
             if prev["eliminated"][p] == 0 and s.eliminated[p] == 1:
                 reward += cfg.dense_elimination_bonus
+        # Potential-based progress shaping toward winning: reward increases in
+        # territory margin (own lead over the strongest rival). Telescopes to
+        # the win, densifying the gradient toward conquering/eliminating without
+        # distorting the optimal policy.
+        if cfg.dense_progress_weight != 0.0:
+            prev_margin = self._margin_from_owner(prev["territory_owner"], player)
+            curr_margin = self.territory_margin(player)
+            reward += cfg.dense_progress_weight * (curr_margin - prev_margin)
+        # Per-step living penalty: pressure to finish games rather than turtle.
+        reward += cfg.step_penalty
         return reward
+
+    def _margin_from_owner(self, owner: np.ndarray, player: int) -> float:
+        """Territory margin (own lead over strongest rival, [-1,1]) for an owner array."""
+        if owner.size == 0 or player >= self.state.n_players:
+            return 0.0
+        counts = np.bincount(owner, minlength=self.state.n_players)
+        own = int(counts[player])
+        opponents = [int(counts[p]) for p in range(self.state.n_players) if p != player]
+        best_opp = max(opponents) if opponents else 0
+        return (own - best_opp) / NUM_TERRITORIES
 
     def _snapshot(self) -> dict[str, Any]:
         s = self.state

--- a/src/models/ppo.py
+++ b/src/models/ppo.py
@@ -19,16 +19,29 @@ _log = get_logger("ppo")
 class PPOTrainer:
     """PPO clipped-surrogate loss trainer."""
 
-    def __init__(self, net: ActorCritic, config: PPOConfig):
+    def __init__(
+        self,
+        net: ActorCritic,
+        config: PPOConfig,
+        reference_net: ActorCritic | None = None,
+    ):
         """Initialize trainer with network and hyperparameters.
 
         Args:
             net: Actor-Critic network to train.
             config: PPO hyperparameters.
+            reference_net: Optional frozen policy (e.g. the BC clone) to anchor
+                the learner toward via ``config.kl_ref_coef`` (RLHF-style). Kept
+                in eval mode with grads off; only its log-probs are used.
         """
         self.net = net
         self.config = config
         self.optimizer = torch.optim.Adam(net.parameters(), lr=config.lr)
+        self.reference_net = reference_net
+        if reference_net is not None:
+            reference_net.eval()
+            for p in reference_net.parameters():
+                p.requires_grad = False
 
     def save_checkpoint(self) -> dict[str, Any]:
         """Return trainer state for checkpointing."""
@@ -59,6 +72,7 @@ class PPOTrainer:
             "approx_kl": 0.0,
             "clip_fraction": 0.0,
             "explained_variance": 0.0,
+            "kl_ref": 0.0,
         }
 
         target_kl = getattr(self.config, "target_kl", 0.0)
@@ -162,10 +176,24 @@ class PPOTrainer:
 
         entropy_loss = -entropy.mean()
 
+        kl_ref = 0.0
+        ref_penalty = torch.zeros((), device=new_log_probs.device)
+        if self.reference_net is not None and self.config.kl_ref_coef > 0:
+            with torch.no_grad():
+                _, ref_log_probs, _, _ = self.reference_net.get_action_and_value(
+                    obs, action=actions, action_masks=action_masks
+                )
+            # Anchor toward the reference (BC) policy on the chosen actions:
+            # squared log-prob deviation — always ≥0, stable, pulls the policy
+            # back when it drifts off the competent BC start.
+            ref_penalty = (new_log_probs - ref_log_probs).pow(2).mean()
+            kl_ref = ref_penalty.item()
+
         total_loss = (
             policy_loss
             + self.config.value_loss_coef * value_loss
             + self.config.entropy_coef * entropy_loss
+            + self.config.kl_ref_coef * ref_penalty
         )
 
         self.optimizer.zero_grad()
@@ -189,6 +217,7 @@ class PPOTrainer:
             "approx_kl": approx_kl,
             "clip_fraction": clip_fraction,
             "explained_variance": explained_variance,
+            "kl_ref": kl_ref,
         }
 
     def _explained_variance(self, returns: torch.Tensor, values: torch.Tensor) -> float:

--- a/src/utils/reward_config.py
+++ b/src/utils/reward_config.py
@@ -28,6 +28,20 @@ class RewardConfig:
     dense_army_ratio: float = 0.005
     dense_elimination_bonus: float = 0.1
     invalid_action_penalty: float = -0.01
+    # Per-step living penalty applied every non-terminal decision. Negative
+    # values make stalling costly so the agent is pushed to *finish* games
+    # (attack, eliminate, win) instead of turtling to a margin lead. Default 0.0
+    # keeps the original behaviour; set a small negative (e.g. -1e-3) to break
+    # the non-resolving turtle equilibrium seen in self-play.
+    step_penalty: float = 0.0
+    # Potential-based progress shaping (Ng et al.): each step adds
+    # ``dense_progress_weight * (margin_now - margin_prev)`` where margin is the
+    # territory lead over the strongest opponent in [-1, 1]. Rewards every move
+    # that increases relative dominance (conquering / eliminating, esp. vs the
+    # leader) and telescopes to the win, giving a dense gradient toward winning
+    # without distorting the optimal policy. The main lever for breaking the
+    # turtle equilibrium. 0.0 disables.
+    dense_progress_weight: float = 0.0
     # Terminal signal when a game hits the turn cap without an elimination
     # (a draw). The learner's final transition receives
     # ``terminal_margin_weight * margin`` where ``margin`` is the territory

--- a/tests/test_bc_dataset.py
+++ b/tests/test_bc_dataset.py
@@ -656,6 +656,8 @@ class _RewardStub:
     dense_army_ratio: float = 0.005
     dense_elimination_bonus: float = 0.1
     invalid_action_penalty: float = -0.01
+    step_penalty: float = 0.0
+    dense_progress_weight: float = 0.0
     terminal_margin_weight: float = 0.5
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,10 +67,10 @@ class TestRewardConfig:
         assert cfg.sparse_loss == -1.0  # default preserved
 
     def test_total_coefficients_count(self):
-        """There must be exactly 8 coefficient fields."""
+        """There must be exactly 10 coefficient fields."""
         cfg = RewardConfig()
         fields = [f for f in cfg.__dataclass_fields__ if not f.startswith("_")]
-        assert len(fields) == 8
+        assert len(fields) == 10
 
     def test_when_field_mutated_then_frozen_instance_error_raised(self):
         """Mutation must raise FrozenInstanceError specifically."""

--- a/training/self_play.py
+++ b/training/self_play.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import random
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -25,7 +26,7 @@ from src.models.replay_buffer import RolloutBuffer
 from src.models.utils import get_obs_dim
 from src.multi_agent import GameResult, MultiAgentRunner
 from src.tb_logger import TensorBoardLogger
-from src.utils.constants import ACTION_DIMS
+from src.utils.constants import ACTION_DIMS, NUM_TERRITORIES
 from src.utils.log import get_logger
 from src.utils.seed import set_global_seeds
 from training.early_stopping import EarlyStopper
@@ -107,6 +108,22 @@ class SelfPlayTrainer:
         self._best_metric_value = 0.0
         self._early_stopper = self._build_early_stopper()
         self._buffer: RolloutBuffer | None = None
+        sp = cfg.self_play
+        self._curriculum_mode: str | None = sp.curriculum_mode if sp.curriculum_enabled else None
+        self._curriculum_results: deque[float] = deque(maxlen=sp.curriculum_window)
+        # Difficulty knob: territory mode → opponent_territories (grows to the
+        # even share = full game); army mode → learner army multiplier (shrinks
+        # to 1.0 = balanced full game).
+        if self._curriculum_mode == "army":
+            self._curriculum_val: float = sp.curriculum_army_start
+            _log.info("curriculum ON (army): start multiplier=%.1f → 1.0", self._curriculum_val)
+        elif self._curriculum_mode == "territory":
+            self._curriculum_val = float(sp.curriculum_start)
+            _log.info(
+                "curriculum ON (territory): start opponent_territories=%d → full=%d",
+                int(self._curriculum_val),
+                NUM_TERRITORIES // sp.n_players,
+            )
 
     # ------------------------------------------------------------------
     # Public API
@@ -178,6 +195,7 @@ class SelfPlayTrainer:
             self._set_rollout_seed()
             result = self._run_episode(buffer)
             last_result = result
+            self._maybe_advance_curriculum(result)
             self._logger.log_game_result(result, player_id=_LEARNER_ID, episode=self._episode)
             updated = False
             if len(buffer) >= buffer.capacity:
@@ -253,9 +271,34 @@ class SelfPlayTrainer:
 
     def _build_trainer(self) -> tuple[PPOTrainer, PPOAgent]:
         net = self._build_net()
-        trainer = PPOTrainer(net, self._cfg.ppo)
+        reference_net = self._build_reference_net()
+        trainer = PPOTrainer(net, self._cfg.ppo, reference_net=reference_net)
         agent = PPOAgent(net, device=self._device)
         return trainer, agent
+
+    def _build_reference_net(self) -> ActorCritic | None:
+        """Load a frozen BC policy to anchor PPO toward (RLHF-style).
+
+        Enabled when ``ppo.kl_ref_coef > 0`` and ``bc.output_path`` exists.
+        """
+        if self._cfg.ppo.kl_ref_coef <= 0:
+            return None
+        path = Path(self._cfg.bc.output_path)
+        if not path.exists():
+            _log.warning("kl_ref_coef>0 but BC reference %s missing — no anchor", path)
+            return None
+        payload = torch.load(path, weights_only=False)
+        ref = self._build_net()
+        ref.load_state_dict(payload["trainer_state"]["model"])
+        ref.eval()
+        for p in ref.parameters():
+            p.requires_grad = False
+        _log.info(
+            "KL-ref anchor: loaded BC reference %s (coef=%g)",
+            path,
+            self._cfg.ppo.kl_ref_coef,
+        )
+        return ref
 
     def _build_net(self) -> ActorCritic:
         return ActorCritic(
@@ -312,6 +355,7 @@ class SelfPlayTrainer:
 
     def _run_episode(self, buffer: RolloutBuffer) -> GameResult:
         """Play one episode and append learner transitions to *buffer*."""
+        self._env.curriculum = self._curriculum_spec()
         agents = self._build_agents()
         runner = MultiAgentRunner(
             self._env,
@@ -322,6 +366,52 @@ class SelfPlayTrainer:
         result = runner.run_game(seed=self._cfg.seed + self._episode)
         self._buffer_learner_transitions(result, buffer)
         return result
+
+    def _curriculum_spec(self) -> dict[str, float] | None:
+        """Env curriculum dict for the current stage, or None when off."""
+        if self._curriculum_mode == "territory":
+            return {
+                "advantaged_player": _LEARNER_ID,
+                "opponent_territories": int(self._curriculum_val),
+            }
+        if self._curriculum_mode == "army":
+            return {"advantaged_player": _LEARNER_ID, "army_advantage": float(self._curriculum_val)}
+        return None
+
+    def _maybe_advance_curriculum(self, result: GameResult) -> None:
+        """Promote to a harder curriculum stage once the learner reliably wins."""
+        if self._curriculum_mode is None:
+            return
+        self._curriculum_results.append(1.0 if result.winner == _LEARNER_ID else 0.0)
+        sp = self._cfg.self_play
+        if len(self._curriculum_results) < sp.curriculum_window:
+            return
+        win_rate = sum(self._curriculum_results) / len(self._curriculum_results)
+        if win_rate < sp.curriculum_promote_threshold:
+            return
+        self._curriculum_results.clear()
+        if self._curriculum_mode == "territory":
+            self._curriculum_val += sp.curriculum_step
+            if self._curriculum_val >= NUM_TERRITORIES // sp.n_players:
+                self._curriculum_mode = None
+                _log.info("curriculum: win_rate=%.2f → full-game difficulty (off)", win_rate)
+            else:
+                _log.info(
+                    "curriculum: win_rate=%.2f → opponent_territories=%d",
+                    win_rate,
+                    int(self._curriculum_val),
+                )
+        else:  # army
+            self._curriculum_val -= sp.curriculum_army_step
+            if self._curriculum_val <= 1.0:
+                self._curriculum_mode = None
+                _log.info("curriculum: win_rate=%.2f → balanced full game (off)", win_rate)
+            else:
+                _log.info(
+                    "curriculum: win_rate=%.2f → army_multiplier=%.1f",
+                    win_rate,
+                    self._curriculum_val,
+                )
 
     def _buffer_learner_transitions(self, result: GameResult, buffer: RolloutBuffer) -> None:
         """Copy learner transitions straight from trajectory into the rollout buffer.


### PR DESCRIPTION
## Problem
From-scratch PPO self-play **turtled** — 0 eliminations, games never resolved, no win signal (the agent never experiences a win, so it can't learn to win). Earlier sparse + dense rewards rewarded holding a lead, not finishing.

## What this adds
**Reward shaping** (`reward_config.py`, `env.py`):
- `dense_progress_weight` — potential-based shaping on territory margin (own − strongest rival), telescopes to the win. Main lever rewarding offense.
- `step_penalty` — per-step living cost to discourage stalling.
- both default `0.0` (opt-in; no behavior change otherwise).

**Reverse curriculum** (`config.py` `SelfPlayConfig`, `env.py`, `self_play.py`):
- Seeds *reachable* wins, then anneals difficulty as the learner clears each stage (win-rate > `curriculum_promote_threshold` over a window):
  - **territory mode** — learner owns all but `k` enemy territories; `k` grows to the even share (full game). Best bootstrap in practice.
  - **army mode** — balanced territories, learner army-rich (multiplier annealed → 1.0).

**PPO stability** (`PPOConfig`, `self_play.py`):
- `target_kl` epoch early-stop, `normalize_advantage` (SB3 default — fixed the advantage-scale KL blow-up), optional `kl_ref_coef` anchor to a frozen BC reference.

## Results so far
Curriculum bootstraps a from-scratch agent to ~stage 3 (wins near-won boards) — vs the prior 0-win turtle. Closing out 3+ rebuilding territories is the current ceiling (future work: stronger exploration / capacity).

## Verification
- `ruff check` clean.
- `pytest -m "not integration"` green (RewardConfig field count test updated 8→10; BC reward stub extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)