### PR TITLE
feat(cli): strategy-analysis command + fix checkpoint loading

### DIFF
--- a/risiko_rl/cli.py
+++ b/risiko_rl/cli.py
@@ -352,6 +352,47 @@ def social_eval(
     typer.echo(f"Total negotiation calls: {result.total_negotiation_calls}")
 
 
+@app.command()
+def analyze(
+    checkpoint: Annotated[
+        str, typer.Option("--checkpoint", help="Agent checkpoint path or 'random'")
+    ] = "random",
+    opponent: Annotated[str, typer.Option("--opponent", help="Opponent agent spec")] = "random",
+    n_games: Annotated[int, typer.Option("--n-games", help="Games to analyze")] = 50,
+    n_players: Annotated[int, typer.Option("--n-players", help="Total players")] = 2,
+    seed: Annotated[int, typer.Option("--seed", help="Base RNG seed")] = 42,
+    max_turns: Annotated[int, typer.Option("--max-turns", help="Turn cap per game")] = 500,
+    output: Annotated[
+        Path | None, typer.Option("--output", "-o", help="Write JSON report")
+    ] = None,
+):
+    """Analyze a trained agent's learned strategy (continent priority, aggression, cards)."""
+    setup_logging()
+    import json  # noqa: PLC0415
+
+    from src.env import RisikoEnv  # noqa: PLC0415
+    from src.multi_agent import MultiAgentRunner  # noqa: PLC0415
+    from training.strategy_analysis import StrategyAnalyzer  # noqa: PLC0415
+
+    learner = load_agent(checkpoint)
+    agents = [learner] + [load_agent(opponent, seed=seed + i) for i in range(1, n_players)]
+
+    typer.echo(f"analyze: {checkpoint} vs {opponent} over {n_games} games ...")
+    results = []
+    for g in range(n_games):
+        env = RisikoEnv(n_players=n_players)
+        results.append(MultiAgentRunner(env, agents, max_turns=max_turns).run_game(seed=seed + g))
+
+    resolved = sum(1 for r in results if r.winner is not None)
+    wins = sum(1 for r in results if r.winner == 0)
+    report = StrategyAnalyzer(results, learner_id=0).report()
+    typer.echo(f"\ngames={n_games} resolved={resolved} learner_wins={wins}")
+    typer.echo(json.dumps(report, indent=2, default=float))
+    if output is not None:
+        output.write_text(json.dumps(report, indent=2, default=float))
+        typer.echo(f"\nreport saved to {output}")
+
+
 def _build_pool(profiles: Path | None, n_players: int) -> list[Any]:
     if profiles is not None:
         from risiko_rl.agent_loader import load_llm_pool  # noqa: PLC0415

--- a/src/utils/safe_torch.py
+++ b/src/utils/safe_torch.py
@@ -57,7 +57,17 @@ def _numpy_safe_globals() -> list[Any]:
         allow.append(reconstruct)
     dtypes_mod = getattr(np, "dtypes", None)
     if dtypes_mod is not None:
-        for name in ("UInt32DType", "Int64DType", "Float64DType"):
+        for name in (
+            "UInt8DType",
+            "Int8DType",
+            "Int16DType",
+            "UInt32DType",
+            "Int32DType",
+            "Int64DType",
+            "Float32DType",
+            "Float64DType",
+            "BoolDType",
+        ):
             klass = getattr(dtypes_mod, name, None)
             if klass is not None:
                 allow.append(klass)


### PR DESCRIPTION
## What
- **`risiko-rl analyze`** — new command driving `StrategyAnalyzer`: runs a trained agent over N games and reports continent priority, attack aggressiveness, card-trade timing, fortification patterns, and attack-distance distribution (JSON, optional `--output`). Completes the eval toolkit (win-rate was already scriptable via `evaluate` / `social-eval`; the strategy report had no CLI).
- **Fix `safe_torch`** — the `weights_only=True` allowlist was missing `Int32DType` (our checkpoints store int32 board/RNG arrays), so `load_agent` — and therefore `evaluate` / `analyze` / `watch` — **could not load any `.pt` checkpoint**. Added the common int/float/bool dtypes.

## Eval workflow (for a trained checkpoint)
```
risiko-rl evaluate --agent-a models/best.pt --agent-b random      # win-rate vs random baseline
risiko-rl social-eval --checkpoint models/best.pt --profiles config/default_6p.yaml  # vs coordinating gemma + diplomacy
risiko-rl analyze --checkpoint models/best.pt -o report.json       # learned-strategy report
```

## Verification
- `ruff` clean; `evaluate` + `analyze` + checkpoint load run end-to-end on a real checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)