### PR TITLE
feat(train): mix balanced full-game episodes into the curriculum

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -141,6 +141,13 @@ class SelfPlayConfig:
     curriculum_army_step: float = 0.5  # (army) multiplier reduction per promotion (toward 1.0)
     curriculum_promote_threshold: float = 0.7  # learner win-rate to advance a stage
     curriculum_window: int = 50  # games over which the stage win-rate is measured
+    # Fraction of episodes that use a balanced full-game start instead of the
+    # curriculum near-won start. The curriculum teaches closeouts but only ever
+    # shows near-won states, so the policy never learns full-game play and
+    # fails to generalize (0% vs random in full games). Mixing in balanced
+    # episodes trains on the eval distribution. These episodes do not count
+    # toward curriculum-stage promotion.
+    curriculum_balanced_fraction: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/training/self_play.py
+++ b/training/self_play.py
@@ -112,6 +112,7 @@ class SelfPlayTrainer:
         sp = cfg.self_play
         self._curriculum_mode: str | None = sp.curriculum_mode if sp.curriculum_enabled else None
         self._curriculum_results: deque[float] = deque(maxlen=sp.curriculum_window)
+        self._last_balanced: bool = False  # was the last episode a balanced (non-curriculum) one
         # Difficulty knob: territory mode → opponent_territories (grows to the
         # even share = full game); army mode → learner army multiplier (shrinks
         # to 1.0 = balanced full game).
@@ -361,7 +362,14 @@ class SelfPlayTrainer:
 
     def _run_episode(self, buffer: RolloutBuffer) -> GameResult:
         """Play one episode and append learner transitions to *buffer*."""
-        self._env.curriculum = self._curriculum_spec()
+        # Mix in balanced full-game episodes so the policy trains on the eval
+        # distribution (not only near-won curriculum states). These episodes are
+        # flagged so they don't count toward curriculum-stage promotion.
+        frac = self._cfg.self_play.curriculum_balanced_fraction
+        self._last_balanced = (
+            self._curriculum_mode is not None and frac > 0 and self._rng.random() < frac
+        )
+        self._env.curriculum = None if self._last_balanced else self._curriculum_spec()
         agents = self._build_agents()
         runner = MultiAgentRunner(
             self._env,
@@ -386,8 +394,8 @@ class SelfPlayTrainer:
 
     def _maybe_advance_curriculum(self, result: GameResult) -> None:
         """Promote to a harder curriculum stage once the learner reliably wins."""
-        if self._curriculum_mode is None:
-            return
+        if self._curriculum_mode is None or self._last_balanced:
+            return  # balanced full-game episodes don't gate stage promotion
         self._curriculum_results.append(1.0 if result.winner == _LEARNER_ID else 0.0)
         sp = self._cfg.self_play
         if len(self._curriculum_results) < sp.curriculum_window:


### PR DESCRIPTION
## Why
Eval exposed the core flaw: the curriculum-trained agent gets **0% vs random in full 2p games** (92% draws) despite clearing curriculum stages. Cause — the reverse curriculum only ever starts the learner in **near-won** states, so it learns closeouts but never **full-game play**; at a balanced eval start it's out-of-distribution.

## Fix
`SelfPlayConfig.curriculum_balanced_fraction` — that fraction of training episodes use a **balanced full-game start** (`env.curriculum=None`) instead of the near-won curriculum start, so training covers the **eval distribution**. Balanced episodes are flagged and **excluded from stage promotion** (the curriculum gate still measures closeout skill on curriculum episodes only). Default `0.0` → no behavior change.

Training run launched with `curriculum_balanced_fraction=0.3`.

## Verification
- `ruff` clean; `pytest -m "not integration"` (config/self_play/curriculum) green.

Directly targets the 0%-generalization result; re-eval vs random after training will tell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)