### PR TITLE
fix(ci): stop gitignoring models/ + checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,7 +227,3 @@ data/bc/
 # pytest tmp_path basetemp + torch inductor cache (machine-local junk)
 pytest-of-*/
 torchinductor_*/
-models/
-*.pt
-*.ckpt
-*.pth


### PR DESCRIPTION
## Why
main CI went red after the tournament commits: `2ca0a89` added `models/`, `*.pt`, `*.ckpt`, `*.pth` to `.gitignore`, violating the repo invariant that checkpoints stay trackable. 3 tests failed:
- `test_bc_global_criteria::...models_directory_is_not_excluded`
- `test_bc_pretrain_config::...models_directory_is_not_globally_ignored`
- `test_bc_workflow_docs::...models_checkpoints_are_not_ignored`

## Fix
Remove those 4 patterns from `.gitignore` (keep the machine-local `pytest-of-*/` / `torchinductor_*/` ignores). Restores the green-at-#113 state.

## Verification
- `ruff check . tests` clean; the 3 (+related) gitignore tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)