### PR TITLE
fix(tournament): recover fenced negotiation JSON + configurable max_turns

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -19,6 +19,12 @@ max_concurrency: 6   # one concurrent game per model seat (I/O-bound LLM calls)
 # ── Diplomacy ────────────────────────────────────────────────────────────────
 n_rounds: 2  # negotiation rounds per diplomacy cycle (spec: 2–3)
 
+# ── Per-game turn cap (draw backstop + cost bound) ───────────────────────────
+# 6-player games need ~150-200 player-turns to reach a winner; lower values
+# trade resolution for speed (more draws). Each turn drives many slow LLM calls,
+# so this also bounds per-game wall-clock/cost.
+max_turns: 200
+
 # ── Strategy catalog reference (by module path, not by value) ────────────────
 strategy_catalog: src.agents.strategies
 

--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -95,8 +95,11 @@ _NEGOTIATION_SCHEMA: dict[str, Any] = {
 
 _NEGOTIATION_SYSTEM = (
     "You are a Risiko diplomat. Based on the board state and current alliances, "
-    "emit ONLY a JSON negotiation object with integer-array fields. "
-    "Do not write any prose — output the JSON object and nothing else."
+    "emit ONLY a JSON object with EXACTLY these four keys, each a list of "
+    'player-index integers (use [] for none): "propose_alliance_with", '
+    '"accept_alliance_with", "declare_war_on", "attack_priority". '
+    "Do not invent other key names. Do not wrap the JSON in markdown code "
+    "fences. Do not write any prose — output the raw JSON object and nothing else."
 )
 
 # System message enforcing JSON-only output. The native `format` mask already
@@ -399,6 +402,22 @@ def _post_negotiation(
         return None
 
 
+def _extract_json_object(content: str) -> str | None:
+    """Isolate the outermost ``{...}`` span from a model reply.
+
+    Cloud models often ignore the native ``format`` schema and wrap the object
+    in markdown code fences (```json … ```) or surround it with prose. Slicing
+    from the first ``{`` to the last ``}`` recovers the object in all those
+    cases (fences and prose live outside the braces); returns ``None`` when no
+    brace pair is present.
+    """
+    start = content.find("{")
+    end = content.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    return content[start : end + 1]
+
+
 def _parse_negotiation(data: dict[str, Any]) -> dict[str, Any] | None:
     """Extract negotiation dict from raw Ollama reply; None on any failure."""
     message = data.get("message") or {}
@@ -409,8 +428,12 @@ def _parse_negotiation(data: dict[str, Any]) -> dict[str, Any] | None:
     if data.get("done_reason") == "length":
         _log.warning("negotiation: response truncated (done_reason=length) → None")
         return None
+    candidate = _extract_json_object(content)
+    if candidate is None:
+        _log.warning("negotiation: no JSON object in %.80r", content)
+        return None
     try:
-        parsed = json.loads(content)
+        parsed = json.loads(candidate)
     except (json.JSONDecodeError, ValueError):
         _log.warning("negotiation: JSON parse error on %.80r", content)
         return None

--- a/tests/test_negotiation_client.py
+++ b/tests/test_negotiation_client.py
@@ -188,6 +188,39 @@ def test_when_messages_to_is_absent_then_constrained_fields_still_parse():
         assert "propose_alliance_with" in result
 
 
+def test_when_content_is_markdown_fenced_then_json_is_recovered():
+    """Cloud models wrap the object in ```json fences; the fence is stripped."""
+    inner = json.dumps(
+        {
+            "propose_alliance_with": [1, 2],
+            "accept_alliance_with": [],
+            "declare_war_on": [3],
+            "attack_priority": [3],
+        }
+    )
+    content = f"```json\n{inner}\n```"
+    with patch("src.agents.ollama_client.httpx") as mock_httpx:
+        mock_httpx.post.return_value = _make_http_ok(content=content)
+
+        result = _call()
+
+        assert isinstance(result, dict)
+        assert result["propose_alliance_with"] == [1, 2]
+        assert result["declare_war_on"] == [3]
+
+
+def test_when_content_has_prose_around_object_then_json_is_recovered():
+    """Prose before/after the object is ignored; the {...} span is parsed."""
+    content = 'Here is my move:\n{"propose_alliance_with": [1], "attack_priority": []}\nGood luck.'
+    with patch("src.agents.ollama_client.httpx") as mock_httpx:
+        mock_httpx.post.return_value = _make_http_ok(content=content)
+
+        result = _call()
+
+        assert isinstance(result, dict)
+        assert result["propose_alliance_with"] == [1]
+
+
 def test_when_content_is_empty_then_none_is_returned_without_exception():
     """Empty response content falls back to None (same contract as action client)."""
     with patch("src.agents.ollama_client.httpx") as mock_httpx:

--- a/training/tournament.py
+++ b/training/tournament.py
@@ -60,6 +60,9 @@ class TournamentConfig:
     models: tuple[str, ...]
     temperature: float
     top_p: float
+    # Per-game turn cap (draw backstop). LLM games make thousands of slow calls,
+    # so the cap also bounds wall-clock/cost per game; defaults to _MAX_TURNS.
+    max_turns: int = _MAX_TURNS
 
 
 @dataclass(frozen=True)
@@ -145,6 +148,7 @@ def _build_config(raw: dict[str, Any]) -> TournamentConfig:
         models=tuple(models),
         temperature=float(raw.get("temperature", 0.7)),
         top_p=float(raw.get("top_p", 0.9)),
+        max_turns=int(raw.get("max_turns", _MAX_TURNS)),
     )
 
 
@@ -547,7 +551,7 @@ def _play_one_game(
     runner = DiplomacyRunner(
         env=env,
         agents=agents,
-        max_turns=_MAX_TURNS,
+        max_turns=config.max_turns,
         diplomacy_cfg=diplomacy_cfg,
         reputation=book,
         learner_id=-1,


### PR DESCRIPTION
## Problem
The pilot tournament logged **~77% negotiation JSON parse failures** — cloud models ignore the native `/api/chat` `format` schema for the multi-field negotiation object (it's honored for the 1-field action schema), returning markdown-fenced ` ```json ` blocks with **invented key names**. Diplomacy was silently disabled (no alliances ever registered).

## Fix
- `_parse_negotiation` slices the outermost `{...}` span (strips ` ```json ` fences + surrounding prose) before `json.loads`.
- `_NEGOTIATION_SYSTEM` names the four exact required keys and forbids fences → models emit the correct schema even under loose cloud enforcement.
- `TournamentConfig.max_turns` is now configurable (YAML `max_turns`, default 200) — draw backstop + per-game cost bound.

## Verification
- **Live**: glm-5.2 / minimax-m3 / qwen3.5 all return `parsed=True` with the exact 4 keys (`propose_alliance_with`, `accept_alliance_with`, `declare_war_on`, `attack_priority`).
- New tests: markdown-fenced + prose-wrapped recovery. `ruff` clean; tournament config/driver/negotiation tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)