### PR TITLE
fix(tournament): resolve capped games by territory leader

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -33,6 +33,14 @@ max_turns: 200
 # move so it cannot stall a game. (minimax-m3 was dropped for taking ~74s/action.)
 action_timeout: 45
 
+# ── Draw resolution ──────────────────────────────────────────────────────────
+# 6-player games rarely eliminate down to one survivor within max_turns, so
+# "territory" scores the board leader (most territories, tie-break armies) as the
+# winner at the cap — giving the leaderboard signal. True elimination wins are
+# always recorded as such; the ledger's `resolution` field distinguishes them.
+# Set "none" to record uncapped draws as winner=None instead.
+draw_resolution: territory
+
 # ── Strategy catalog reference (by module path, not by value) ────────────────
 strategy_catalog: src.agents.strategies
 

--- a/tests/test_draw_resolution.py
+++ b/tests/test_draw_resolution.py
@@ -1,0 +1,114 @@
+"""Tests for tournament draw-resolution: territory-leader fallback at the turn cap.
+
+6-player games rarely eliminate down to one survivor within max_turns, so a game
+that hits the cap is scored by board leadership (most territories, tie-break by
+armies) when draw_resolution="territory". True elimination wins are unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from types import SimpleNamespace
+
+import numpy as np
+
+from training.tournament import (
+    LedgerRecord,
+    _territory_leader,
+    load_tournament_config,
+)
+
+CONFIG_PATH = pathlib.Path("config/tournament.yaml")
+
+
+def _state(owner: list[int], armies: list[int], eliminated: list[int], n: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        territory_owner=np.array(owner),
+        armies=np.array(armies),
+        eliminated=np.array(eliminated),
+        n_players=n,
+    )
+
+
+# ── _territory_leader ────────────────────────────────────────────────────────
+
+
+def test_when_one_player_holds_most_territories_then_that_player_leads():
+    st = _state([0, 1, 1, 1, 2], [9, 1, 1, 1, 1], [0, 0, 0], 3)
+    assert _territory_leader(st) == 1
+
+
+def test_when_territories_tied_then_armies_break_the_tie():
+    st = _state([0, 1], [2, 5], [0, 0], 2)
+    assert _territory_leader(st) == 1
+
+
+def test_when_leader_is_eliminated_then_excluded_from_ranking():
+    # p1 holds the most land but is eliminated → leader is p0 (1 terr, most armies).
+    st = _state([1, 1, 1, 0, 2], [1, 1, 1, 9, 1], [0, 1, 0], 3)
+    assert _territory_leader(st) == 0
+
+
+def test_when_no_active_player_holds_territory_then_none():
+    st = _state([0, 0], [3, 3], [1, 1], 2)
+    assert _territory_leader(st) is None
+
+
+def test_when_territories_and_armies_tie_then_lowest_index_wins():
+    st = _state([0, 1], [3, 3], [0, 0], 2)
+    assert _territory_leader(st) == 0
+
+
+# ── config field ─────────────────────────────────────────────────────────────
+
+
+def test_when_config_loaded_then_draw_resolution_is_territory():
+    cfg = load_tournament_config(CONFIG_PATH)
+    assert cfg.draw_resolution == "territory"
+
+
+# ── LedgerRecord.resolution ──────────────────────────────────────────────────
+
+
+def _record(resolution: str = "draw") -> LedgerRecord:
+    return LedgerRecord(
+        game_index=0,
+        seed=1,
+        winner=2,
+        winner_strategy="aggressive_blitz",
+        winner_model="glm-5.2:cloud",
+        n_turns=200,
+        elimination_order=[],
+        seat_strategies={},
+        seat_models={},
+        assignment={},
+        card_trade_turns=[],
+        llm_call_count=10,
+        resolution=resolution,
+    )
+
+
+def test_when_resolution_set_then_round_trips_through_json():
+    rec = _record(resolution="territory_cap")
+    restored = LedgerRecord.from_json(json.loads(rec.to_json_line()))
+    assert restored.resolution == "territory_cap"
+
+
+def test_when_old_ledger_line_lacks_resolution_then_defaults_to_draw():
+    """Back-compat: a record dict without `resolution` (pre-field ledger) loads."""
+    data = {
+        "game_index": 0,
+        "seed": 1,
+        "winner": None,
+        "winner_strategy": None,
+        "winner_model": None,
+        "n_turns": 200,
+        "elimination_order": [],
+        "seat_strategies": {},
+        "seat_models": {},
+        "assignment": {},
+        "card_trade_turns": [],
+        "llm_call_count": 5,
+    }
+    assert LedgerRecord.from_json(data).resolution == "draw"

--- a/training/tournament.py
+++ b/training/tournament.py
@@ -69,6 +69,12 @@ class TournamentConfig:
     # Per-action LLM timeout (s). A model exceeding this falls back to a random
     # legal move, so a slow/verbose model can't stall a whole game.
     action_timeout: float = 120.0
+    # How to score a game with no sole survivor at the turn cap. "territory":
+    # the board leader (most territories, tie-break by armies) is the winner, so
+    # the leaderboard has signal even when 6p games don't eliminate to 1 within
+    # max_turns. "none": record a draw (winner=None). True elimination victories
+    # are always recorded as wins regardless of this setting.
+    draw_resolution: str = "territory"
 
 
 @dataclass(frozen=True)
@@ -96,6 +102,10 @@ class LedgerRecord:
     assignment: dict[str, str]
     card_trade_turns: list[int]
     llm_call_count: int
+    # How the winner was decided: "elimination" (sole survivor), "territory_cap"
+    # (board leader at max_turns), or "draw" (no winner). Lets analysis separate
+    # decisive wins from cap-resolved ones. Defaulted for old-ledger from_json.
+    resolution: str = "draw"
 
     def to_json_line(self) -> str:
         """Serialise to a single JSON line with no trailing newline."""
@@ -157,6 +167,7 @@ def _build_config(raw: dict[str, Any]) -> TournamentConfig:
         max_turns=int(raw.get("max_turns", _MAX_TURNS)),
         negotiation_cadence=int(raw.get("negotiation_cadence", 1)),
         action_timeout=float(raw.get("action_timeout", 120.0)),
+        draw_resolution=str(raw.get("draw_resolution", "territory")),
     )
 
 
@@ -512,6 +523,31 @@ def build_negotiation_call_fn(
     return fn
 
 
+def _territory_leader(state: Any) -> int | None:
+    """Seat leading the board at the turn cap, or None if no one holds territory.
+
+    Ranks non-eliminated players by territory count, tie-broken by total armies
+    then lowest seat index. Used to resolve a winner when a game reaches
+    max_turns without a sole survivor (``draw_resolution="territory"``).
+    """
+    owner = np.asarray(state.territory_owner)
+    armies = np.asarray(state.armies)
+    eliminated = np.asarray(state.eliminated)
+    best: int | None = None
+    best_key = (-1, -1)
+    for p in range(int(state.n_players)):
+        if eliminated[p]:
+            continue
+        terr = int(np.sum(owner == p))
+        if terr == 0:
+            continue
+        key = (terr, int(np.sum(armies[owner == p])))
+        if key > best_key:
+            best_key = key
+            best = p
+    return best
+
+
 def run_game(
     plan: GamePlan,
     config: TournamentConfig,
@@ -582,6 +618,12 @@ def _play_one_game(
     total_llm_calls = action_calls + runner.call_count
 
     winner = result.winner
+    resolution = "elimination" if winner is not None else "draw"
+    if winner is None and config.draw_resolution == "territory":
+        winner = _territory_leader(env.state)
+        if winner is not None:
+            resolution = "territory_cap"
+
     winner_strategy: str | None = None
     winner_model: str | None = None
     if winner is not None:
@@ -604,6 +646,7 @@ def _play_one_game(
         assignment=dict(plan.assignment),
         card_trade_turns=result.card_trade_turns,
         llm_call_count=total_llm_calls,
+        resolution=resolution,
     )
 
 


### PR DESCRIPTION
## Problem
The fast pilot confirmed throughput is solved, but exposed the real blocker: **6-player LLM games don't eliminate down to one survivor within `max_turns`** (0 eliminations across 6 games after ~32 turns each). `_resolve_winner` only returns a winner when exactly one player remains, so every capped game recorded `winner=None` — **the leaderboard would have zero winners and answer nothing.**

## Fix
`draw_resolution` (config, default `"territory"`): when a game hits the cap with no sole survivor, score the **board leader** (most territories, tie-break total armies, then lowest seat) as the winner. True elimination victories are still recorded as wins. New `LedgerRecord.resolution` field (`elimination` | `territory_cap` | `draw`) lets analysis separate decisive from cap-resolved wins. `draw_resolution: "none"` restores `winner=None`.

This is the standard way to score a turn-capped strategy tournament — it measures which strategy *dominates the board*, which is exactly the research question.

## Tests
- `_territory_leader`: most-territories, army tie-break, eliminated-excluded, no-territory→None, index tie-break.
- Config loads `draw_resolution`; `LedgerRecord.resolution` round-trips + back-compat default for old ledgers.
- ruff clean; tournament config/driver/resumable/smoke tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)