### PR TITLE
feat(tournament): real placement + alliance/betrayal leaderboard stats

### DIFF
--- a/src/agents/diplomacy.py
+++ b/src/agents/diplomacy.py
@@ -6,7 +6,7 @@ any context (training or eval) without side effects.
 
 from __future__ import annotations
 
-from collections import deque
+from collections import defaultdict, deque
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
@@ -65,14 +65,26 @@ class DiplomacyState:
         self.grudges: list[Grudge] = []
         self.message_log: deque[Message] = deque(maxlen=max_log)
         self.decay = decay
+        # Per-game tally of distinct alliances each player has formed (counts a
+        # pair once, on first formation — re-proposing an existing alliance does
+        # not re-count). Consumed by the tournament leaderboard.
+        self.alliance_formations: dict[int, int] = defaultdict(int)
 
     def are_allied(self, a: int, b: int) -> bool:
         """Return True if a and b share an alliance (symmetric)."""
         return _pair(a, b) in self.alliances
 
     def form_alliance(self, a: int, b: int) -> None:
-        """Add an alliance between a and b; idempotent."""
-        self.alliances.add(_pair(a, b))
+        """Add an alliance between a and b; idempotent.
+
+        The first time a pair is formed, both members' formation tallies are
+        incremented; re-forming an existing alliance is a no-op (no double-count).
+        """
+        pair = _pair(a, b)
+        if pair not in self.alliances:
+            self.alliances.add(pair)
+            self.alliance_formations[a] += 1
+            self.alliance_formations[b] += 1
 
     def break_alliance(self, a: int, b: int) -> None:
         """Remove the alliance between a and b; no-op if absent."""

--- a/tests/test_draw_resolution.py
+++ b/tests/test_draw_resolution.py
@@ -13,11 +13,14 @@ from types import SimpleNamespace
 
 import numpy as np
 
+from src.agents.diplomacy import DiplomacyState
 from training.tournament import (
     LedgerRecord,
+    _final_ranking,
     _territory_leader,
     load_tournament_config,
 )
+from training.tournament_stats import placements
 
 CONFIG_PATH = pathlib.Path("config/tournament.yaml")
 
@@ -58,6 +61,66 @@ def test_when_no_active_player_holds_territory_then_none():
 def test_when_territories_and_armies_tie_then_lowest_index_wins():
     st = _state([0, 1], [3, 3], [0, 0], 2)
     assert _territory_leader(st) == 0
+
+
+# ── _final_ranking ───────────────────────────────────────────────────────────
+
+
+def test_when_no_eliminations_then_ranking_orders_survivors_by_territory():
+    # p1 holds 3 terr, p0 1, p2 1 (p0 more armies than p2) → [1, 0, 2].
+    st = _state([0, 1, 1, 1, 2], [9, 1, 1, 1, 1], [0, 0, 0], 3)
+    assert _final_ranking(st, []) == [1, 0, 2]
+
+
+def test_when_players_eliminated_then_they_rank_after_survivors_reverse_order():
+    # p0 survives (all land); p1 then p2 eliminated → survivors first, then
+    # eliminated in reverse elimination order (last out ranks higher): [0, 2, 1].
+    st = _state([0, 0, 0, 0], [4, 4, 4, 4], [0, 1, 1], 3)
+    assert _final_ranking(st, [1, 2]) == [0, 2, 1]
+
+
+def test_when_ranking_first_then_matches_territory_leader():
+    st = _state([0, 1, 1, 1, 2], [9, 1, 1, 1, 1], [0, 0, 0], 3)
+    assert _final_ranking(st, [])[0] == _territory_leader(st)
+
+
+# ── placements use final_ranking ─────────────────────────────────────────────
+
+
+def test_when_record_has_final_ranking_then_placements_are_distinct():
+    rec = {
+        "seat_strategies": {"0": "a", "1": "b", "2": "c"},
+        "elimination_order": [],
+        "final_ranking": [2, 0, 1],
+    }
+    assert placements(rec) == {2: 1, 0: 2, 1: 3}
+
+
+def test_when_no_final_ranking_then_falls_back_to_elimination_logic():
+    rec = {
+        "seat_strategies": {"0": "a", "1": "b"},
+        "elimination_order": [1],
+    }
+    # p0 survives → 1; p1 eliminated (last out) → 2.
+    assert placements(rec) == {0: 1, 1: 2}
+
+
+# ── alliance formation counter ───────────────────────────────────────────────
+
+
+def test_when_alliance_formed_then_both_members_counted_once():
+    st = DiplomacyState()
+    st.form_alliance(0, 3)
+    st.form_alliance(0, 3)  # re-forming the same pair must not double-count
+    assert st.alliance_formations[0] == 1
+    assert st.alliance_formations[3] == 1
+
+
+def test_when_player_forms_two_alliances_then_count_is_two():
+    st = DiplomacyState()
+    st.form_alliance(0, 1)
+    st.form_alliance(0, 2)
+    assert st.alliance_formations[0] == 2
 
 
 # ── config field ─────────────────────────────────────────────────────────────

--- a/training/tournament.py
+++ b/training/tournament.py
@@ -11,7 +11,7 @@ import os
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -106,6 +106,14 @@ class LedgerRecord:
     # (board leader at max_turns), or "draw" (no winner). Lets analysis separate
     # decisive wins from cap-resolved ones. Defaulted for old-ledger from_json.
     resolution: str = "draw"
+    # Final seat ordering best→worst (winner first): survivors by board strength
+    # then eliminated in reverse elimination order. Drives real placement stats
+    # even when no one is eliminated. Empty for old ledgers (falls back to elim).
+    final_ranking: list[int] = field(default_factory=list)
+    # Per-seat diplomacy tallies for this game: distinct alliances formed, and
+    # betrayals (attacking a current ally). Seat-index keyed; empty when none.
+    alliances: dict[str, int] = field(default_factory=dict)
+    betrayals: dict[str, int] = field(default_factory=dict)
 
     def to_json_line(self) -> str:
         """Serialise to a single JSON line with no trailing newline."""
@@ -548,6 +556,31 @@ def _territory_leader(state: Any) -> int | None:
     return best
 
 
+def _final_ranking(state: Any, elimination_order: list[int]) -> list[int]:
+    """Seats ordered best→worst at game end (winner first).
+
+    Survivors (non-eliminated) rank ahead of eliminated seats, ordered by
+    territory count then total armies (lowest index breaks remaining ties).
+    Eliminated seats follow in reverse elimination order (last out ranks higher).
+    Position i in the returned list is finishing place i+1.
+    """
+    owner = np.asarray(state.territory_owner)
+    armies = np.asarray(state.armies)
+    eliminated_flags = np.asarray(state.eliminated)
+    n = int(state.n_players)
+    eliminated = {p for p in range(n) if eliminated_flags[p]}
+    survivors = [p for p in range(n) if p not in eliminated]
+    # Stable sort: equal (territory, armies) keys keep ascending-index order.
+    survivors.sort(
+        key=lambda p: (int(np.sum(owner == p)), int(np.sum(armies[owner == p]))),
+        reverse=True,
+    )
+    elim_ranked = [int(p) for p in reversed(elimination_order)]
+    # Append any eliminated seat missing from elimination_order (defensive).
+    elim_ranked += [p for p in eliminated if p not in elim_ranked]
+    return survivors + elim_ranked
+
+
 def run_game(
     plan: GamePlan,
     config: TournamentConfig,
@@ -574,6 +607,8 @@ def _play_one_game(
     """
     if book is None:
         book = ReputationBook()
+    # The book is session-shared, so snapshot per-player betrayals to diff after.
+    betrayals_before = {p: book.betrayal_count(p) for p in range(_N_PLAYERS)}
     ensure_env_loaded()
     base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
@@ -633,6 +668,18 @@ def _play_one_game(
     seat_strategies = {str(i): list(config.strategies)[i] for i in range(_N_PLAYERS)}
     seat_models = {str(i): seats[i].model for i in range(_N_PLAYERS)}
 
+    final_ranking = _final_ranking(env.state, result.elimination_order)
+    betrayals = {
+        str(p): book.betrayal_count(p) - betrayals_before[p]
+        for p in range(_N_PLAYERS)
+        if book.betrayal_count(p) - betrayals_before[p] > 0
+    }
+    alliances = {
+        str(p): runner._state.alliance_formations[p]
+        for p in range(_N_PLAYERS)
+        if runner._state.alliance_formations.get(p, 0) > 0
+    }
+
     return LedgerRecord(
         game_index=plan.game_index,
         seed=plan.seed,
@@ -647,6 +694,9 @@ def _play_one_game(
         card_trade_turns=result.card_trade_turns,
         llm_call_count=total_llm_calls,
         resolution=resolution,
+        final_ranking=final_ranking,
+        alliances=alliances,
+        betrayals=betrayals,
     )
 
 

--- a/training/tournament_stats.py
+++ b/training/tournament_stats.py
@@ -271,10 +271,18 @@ def _safe_wilson(wins: int, n: int) -> tuple[float, float]:
 def placements(rec: dict) -> dict[int, int]:
     """Map every seat in *rec* to its finishing placement (1 = best).
 
-    Seats absent from ``elimination_order`` are survivors → placement 1.
-    Eliminated seats rank from 2 (last out) upward by reverse elimination order.
-    Tolerates a missing or empty ``elimination_order``.
+    Prefers ``final_ranking`` (seats best→worst) when present — this gives real
+    placements even when no one is eliminated (capped games), where every seat
+    would otherwise be a place-1 "survivor". Falls back to the elimination-order
+    rule for older ledgers: survivors → 1, eliminated rank from 2 (last out) up.
     """
+    ranking: list[int] = rec.get("final_ranking") or []
+    if ranking:
+        place = {int(seat): pos + 1 for pos, seat in enumerate(ranking)}
+        last = len(ranking) + 1  # defensively place any unranked seat last
+        for k in rec.get("seat_strategies", {}):
+            place.setdefault(int(k), last)
+        return place
     elim: list[int] = rec.get("elimination_order") or []
     n_elim = len(elim)
     result = {int(k): 1 for k in rec["seat_strategies"]}


### PR DESCRIPTION
## Why
The validation pilot's leaderboard had two flat metrics:
- **`mean_placement` = 1.0 for every strategy** — capped games have no eliminations, so `placements()` treated all six seats as place-1 survivors.
- **`alliances` / `betrayals` = 0 everywhere** — the analysis already reads these per-record, but `LedgerRecord` never carried them.

## Changes
- `DiplomacyState.alliance_formations`: per-game tally of distinct alliances each player forms (counted once on first formation; re-proposing is a no-op).
- `LedgerRecord` gains `final_ranking` (seats best→worst: survivors by territory/armies, then eliminated in reverse elimination order), plus per-seat `alliances` / `betrayals`. `_play_one_game` populates them — alliances from the runner's diplomacy state, betrayals as a per-game delta against the session-shared `ReputationBook`, ranking from final env state.
- `placements()` prefers `final_ranking` → distinct placements even with zero eliminations; falls back to the elimination rule for old ledgers.
- All new fields defaulted → old ledgers load unchanged.

## Tests
- `_final_ranking` (survivor ordering, eliminated reverse-order, matches territory leader), `placements()` with/without `final_ranking`, alliance-formation counter (no double-count), config + ledger round-trip/back-compat.
- ruff clean; stats/diplomacy/matrix/report suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)