### PR TITLE
feat(tournament): wait out Ollama 429 rate/usage limits (no random fallback)

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -14,7 +14,10 @@ seed: 42
 # Start with a 30-game pilot to validate the pipeline; scale to 1000+ games
 # for statistically significant strategy win-rates (Wilson CI).
 n_games: 30
-max_concurrency: 6   # one concurrent game per model seat (I/O-bound LLM calls)
+# Concurrent games. Ollama cloud limits concurrent models per plan (Free 1,
+# Pro 3, Max 10); exceeding it triggers HTTP 429. 3 matches Pro and keeps 429s
+# rare — raise only if your plan allows more concurrency.
+max_concurrency: 3
 
 # ── Diplomacy ────────────────────────────────────────────────────────────────
 n_rounds: 1            # negotiation rounds per cycle (was 2 — halved for throughput)
@@ -28,10 +31,18 @@ negotiation_cadence: 4 # negotiate every 4th player-turn (was every turn) — di
 # so this also bounds per-game wall-clock/cost.
 max_turns: 200
 
-# ── Per-action LLM timeout (s) ───────────────────────────────────────────────
-# Fast models answer in <5s; a model exceeding this falls back to a random legal
-# move so it cannot stall a game. (minimax-m3 was dropped for taking ~74s/action.)
-action_timeout: 45
+# ── Per-HTTP-attempt timeout (s) ─────────────────────────────────────────────
+# Bounds a single HTTP attempt (not the whole call). Fast models answer in <5s;
+# a genuinely hung attempt past this falls back to a random move. The hard
+# wall-clock cap is disabled in the tournament so rate-limit waits aren't killed.
+action_timeout: 120
+
+# ── Rate-limit wait-out (s) ──────────────────────────────────────────────────
+# On HTTP 429 (Ollama-cloud per-minute / 5-hour session / 7-day weekly quota),
+# the client backs off and retries within this budget instead of playing a
+# random move or erroring. Default 1 week (604800s) covers the weekly reset, so
+# the run pauses and resumes automatically when the quota refreshes.
+rate_limit_max_wait: 604800
 
 # ── Draw resolution ──────────────────────────────────────────────────────────
 # 6-player games rarely eliminate down to one survivor within max_turns, so

--- a/src/agents/llm_opponent.py
+++ b/src/agents/llm_opponent.py
@@ -34,23 +34,35 @@ class LLMOpponent(Agent):
         base_url: str | None = None,
         api_key: str | None = None,
         player_config: PlayerConfig | None = None,
+        http_timeout: float | None = None,
+        rate_limit_max_wait: float = 0.0,
     ) -> None:
         """Create an LLM opponent backed by Ollama.
 
         Args:
             model: Model/tag name (overridden by ``player_config.model``), e.g.
                 ``gpt-oss:20b`` (local) or ``gpt-oss:120b`` (cloud).
-            timeout: Hard timeout per LLM call in seconds.
+            timeout: Hard wall-clock cap per call (via a watchdog thread); on
+                expiry the move falls back to random. ``0`` disables the cap so a
+                call that is waiting out a rate limit is never aborted — the
+                per-request ``http_timeout`` still bounds each HTTP attempt.
             temperature: Sampling temperature (overridden by ``player_config``).
             top_p: Nucleus sampling parameter (overridden by ``player_config``).
             strategy_hint: Prompt directive (overridden by ``player_config``).
             base_url: Optional override for ``OLLAMA_BASE_URL``.
             api_key: Optional override for ``OLLAMA_API_KEY``.
             player_config: Per-player sampling profile; takes precedence over scalars.
+            http_timeout: Per-HTTP-attempt timeout (s) passed to the client;
+                defaults to ``timeout`` (or 120 when the hard cap is disabled).
+            rate_limit_max_wait: Seconds to wait out HTTP 429 rate/usage limits
+                before giving up (0 = no waiting). Lets the run pause for the
+                Ollama-cloud session/weekly reset instead of playing random moves.
         """
         self._player_config = player_config
         self._model = player_config.model if player_config else model
         self._timeout = timeout
+        self._http_timeout = http_timeout if http_timeout is not None else (timeout or 120.0)
+        self._rate_limit_max_wait = rate_limit_max_wait
         self._temperature = player_config.temperature if player_config else temperature
         self._top_p = player_config.top_p if player_config else top_p
         self._strategy_hint = player_config.strategy_hint if player_config else strategy_hint
@@ -147,13 +159,22 @@ class LLMOpponent(Agent):
         *,
         diplomacy: DiplomacyNote | None = None,
     ) -> int | None:
-        """Call Ollama with a hard timeout via ThreadPoolExecutor."""
+        """Call Ollama, optionally under a hard wall-clock cap.
+
+        When ``self._timeout`` is falsy the call runs inline with no watchdog,
+        so a long rate-limit wait inside the client is never aborted (each HTTP
+        attempt is still bounded by ``http_timeout``). Otherwise a
+        ThreadPoolExecutor enforces the hard cap and raises on expiry.
+        """
+        kwargs = self._build_ollama_kwargs(diplomacy)
+        if not self._timeout:
+            return _ollama_client.call_ollama_for_action_index(obs, legal_actions, **kwargs)
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(
                 _ollama_client.call_ollama_for_action_index,
                 obs,
                 legal_actions,
-                **self._build_ollama_kwargs(diplomacy),
+                **kwargs,
             )
             return future.result(timeout=self._timeout)
 
@@ -168,11 +189,15 @@ class LLMOpponent(Agent):
             "model": self._model,
             "base_url": self._base_url,
             "api_key": self._api_key,
-            "timeout": self._timeout,
+            "timeout": self._http_timeout,
             "temperature": self._temperature,
             "top_p": self._top_p,
             "strategy_hint": self._strategy_hint,
         }
+        # Added only when enabled so the default-construction call stays
+        # byte-identical to the training path (disabled-equivalence guarantee).
+        if self._rate_limit_max_wait > 0:
+            kwargs["rate_limit_max_wait"] = self._rate_limit_max_wait
         if diplomacy is not None:
             kwargs["diplomacy_note"] = diplomacy
         return kwargs

--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -37,8 +37,10 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import re
 import time
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import httpx
@@ -116,6 +118,73 @@ _SYSTEM_PROMPT = (
 )
 
 
+# Ollama cloud throttles with HTTP 429 — for per-minute/concurrency limits and,
+# importantly, the 5-hour session and 7-day weekly usage quotas. The cloud does
+# not reliably send Retry-After or quota headers (ollama/ollama#15663), so the
+# only robust strategy is: on 429, wait and retry until the limit resets, rather
+# than failing or playing a random move. Backoff is exponential with jitter,
+# capped, and honours Retry-After when present.
+_RATE_LIMIT_STATUS = 429
+_BACKOFF_BASE_S = 5.0
+_BACKOFF_CAP_S = 300.0  # 5 min between polls once backed off — cheap vs a 5h/7d wait
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """Parse a Retry-After header (delta-seconds or HTTP-date) into seconds, or None."""
+    raw = response.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(raw)
+        return max(0.0, when.timestamp() - time.time())
+    except (TypeError, ValueError):
+        return None
+
+
+def _post_waiting_out_rate_limits(
+    url: str,
+    *,
+    headers: dict[str, str],
+    json_body: dict[str, Any],
+    timeout: float,
+    rate_limit_max_wait: float,
+) -> httpx.Response:
+    """POST, transparently waiting out HTTP 429 rate/usage limits.
+
+    On 429 the call sleeps (Retry-After if given, else capped exponential backoff
+    with jitter) and retries until it succeeds or cumulative wait exceeds
+    *rate_limit_max_wait*. ``rate_limit_max_wait <= 0`` disables waiting (a 429
+    raises immediately — legacy behaviour). Non-429 errors propagate unchanged.
+    """
+    start = time.time()
+    attempt = 0
+    while True:
+        response = httpx.post(url, json=json_body, headers=headers, timeout=timeout)
+        if response.status_code != _RATE_LIMIT_STATUS:
+            response.raise_for_status()
+            return response
+        elapsed = time.time() - start
+        if rate_limit_max_wait <= 0 or elapsed >= rate_limit_max_wait:
+            response.raise_for_status()  # give up → propagate the 429
+        wait = _retry_after_seconds(response)
+        if wait is None:
+            wait = min(_BACKOFF_CAP_S, _BACKOFF_BASE_S * (2**attempt))
+            wait += random.uniform(0.0, wait * 0.25)  # jitter to de-sync callers
+        _log.warning(
+            "Ollama 429 rate-limited (session/weekly/RPM quota); waiting %.0fs then "
+            "retrying — elapsed %.0fs of %.0fs budget",
+            wait,
+            elapsed,
+            rate_limit_max_wait,
+        )
+        time.sleep(wait)
+        attempt += 1
+
+
 def call_ollama_for_action_index(
     obs: dict[str, np.ndarray],
     legal_actions: list[dict[str, int]],
@@ -130,6 +199,7 @@ def call_ollama_for_action_index(
     diplomacy_note: DiplomacyNote | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
     think: bool = False,
+    rate_limit_max_wait: float = 0.0,
 ) -> int | None:
     """Call Ollama and return an index into *legal_actions*, or None.
 
@@ -156,6 +226,10 @@ def call_ollama_for_action_index(
             single legal-action index needing no reasoning, and disabling it
             cuts reasoning-model latency ~10-100x. Set True only if a model's
             index quality measurably improves with reasoning.
+        rate_limit_max_wait: Seconds to wait out HTTP 429 rate/usage limits
+            (per call) before giving up; 0 disables waiting (legacy immediate
+            fallback). Lets a run pause for the Ollama-cloud session/weekly
+            reset instead of returning a random move.
 
     Returns:
         An index in ``[0, len(legal_actions))`` chosen by the model, or ``None``
@@ -204,8 +278,13 @@ def call_ollama_for_action_index(
         prompt,
     )
     t0 = time.time()
-    response = httpx.post(url, json=body, headers=headers, timeout=timeout)
-    response.raise_for_status()
+    response = _post_waiting_out_rate_limits(
+        url,
+        headers=headers,
+        json_body=body,
+        timeout=timeout,
+        rate_limit_max_wait=rate_limit_max_wait,
+    )
     elapsed = time.time() - t0
     data = response.json()
     return _parse_index(data, legal_actions, model, elapsed)
@@ -346,11 +425,14 @@ def call_ollama_for_negotiation(
     temperature: float = 0.7,
     timeout: float = 60.0,
     think: bool = False,
+    rate_limit_max_wait: float = 0.0,
 ) -> dict[str, Any] | None:
     """Call Ollama for a negotiation response; returns a parsed dict or None.
 
     Same fallback contract as :func:`call_ollama_for_action_index`: any HTTP,
-    timeout, or parse error returns ``None`` without raising.
+    timeout, or parse error returns ``None`` without raising. HTTP 429
+    rate/usage limits are waited out (see *rate_limit_max_wait*) rather than
+    treated as a failure.
 
     Args:
         root: Ollama root URL, e.g. ``http://localhost:11434`` (no ``/v1``).
@@ -361,10 +443,12 @@ def call_ollama_for_negotiation(
         temperature: Sampling temperature; default 0.7 for varied social play.
         timeout: Per-call HTTP timeout in seconds.
         think: Enable model chain-of-thought. Default False.
+        rate_limit_max_wait: Seconds to wait out HTTP 429 before giving up; 0
+            disables waiting (legacy immediate fallback).
     """
     body = _build_negotiation_body(model, prompt, max_message_tokens, temperature, think)
     headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
-    return _post_negotiation(f"{root}/api/chat", headers, body, timeout)
+    return _post_negotiation(f"{root}/api/chat", headers, body, timeout, rate_limit_max_wait)
 
 
 def _build_negotiation_body(
@@ -392,10 +476,16 @@ def _post_negotiation(
     headers: dict[str, str],
     body: dict[str, Any],
     timeout: float,
+    rate_limit_max_wait: float = 0.0,
 ) -> dict[str, Any] | None:
     try:
-        resp = httpx.post(url, json=body, headers=headers, timeout=timeout)
-        resp.raise_for_status()
+        resp = _post_waiting_out_rate_limits(
+            url,
+            headers=headers,
+            json_body=body,
+            timeout=timeout,
+            rate_limit_max_wait=rate_limit_max_wait,
+        )
         return _parse_negotiation(resp.json())
     except (_HttpxHTTPError, ValueError) as exc:
         _log.warning("call_ollama_for_negotiation error: %s", exc)

--- a/tests/test_108_tournament_config_loader.py
+++ b/tests/test_108_tournament_config_loader.py
@@ -56,12 +56,14 @@ def test_when_tournament_config_loaded_then_n_games_equals_30():
     assert cfg.n_games == 30
 
 
-def test_when_tournament_config_loaded_then_max_concurrency_equals_6():
-    """Criterion: max_concurrency == 6 in the parsed TournamentConfig."""
+def test_when_tournament_config_loaded_then_max_concurrency_is_positive():
+    """max_concurrency must be a positive int (lowered to 3 to avoid 429s —
+    Ollama-cloud limits concurrent models per plan: Free 1, Pro 3, Max 10).
+    """
     from training.tournament import load_tournament_config
 
     cfg = load_tournament_config(CONFIG_PATH)
-    assert cfg.max_concurrency == 6
+    assert cfg.max_concurrency >= 1
 
 
 def test_when_tournament_config_loaded_then_n_rounds_is_at_least_one():

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,111 @@
+"""Tests for HTTP 429 rate/usage-limit wait-out in the Ollama client.
+
+Ollama cloud throttles on per-minute, 5-hour session, and 7-day weekly quotas
+with HTTP 429. The client must wait the limit out (backoff + retry) rather than
+failing or playing a random move. time.sleep is patched so tests don't block.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from src.agents.ollama_client import (
+    _post_waiting_out_rate_limits,
+    _retry_after_seconds,
+)
+
+
+def _resp(status: int = 200, headers: dict | None = None, body: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.json.return_value = body or {}
+
+    def _raise() -> None:
+        if status >= 400:
+            raise httpx.HTTPStatusError("err", request=MagicMock(), response=r)
+
+    r.raise_for_status.side_effect = _raise
+    return r
+
+
+# ── _retry_after_seconds ─────────────────────────────────────────────────────
+
+
+def test_when_retry_after_is_seconds_then_parsed():
+    assert _retry_after_seconds(_resp(429, headers={"retry-after": "12"})) == 12.0
+
+
+def test_when_retry_after_absent_then_none():
+    assert _retry_after_seconds(_resp(429)) is None
+
+
+# ── _post_waiting_out_rate_limits ────────────────────────────────────────────
+
+
+def test_when_first_response_ok_then_returns_without_sleeping():
+    ok = _resp(200, body={"x": 1})
+    with (
+        patch("src.agents.ollama_client.httpx.post", return_value=ok) as post,
+        patch("src.agents.ollama_client.time.sleep") as sleep,
+    ):
+        out = _post_waiting_out_rate_limits(
+            "u", headers={}, json_body={}, timeout=1.0, rate_limit_max_wait=100.0
+        )
+    assert out is ok
+    assert post.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_when_429_then_200_then_waits_and_retries():
+    seq = [_resp(429), _resp(429), _resp(200)]
+    with (
+        patch("src.agents.ollama_client.httpx.post", side_effect=seq) as post,
+        patch("src.agents.ollama_client.time.sleep") as sleep,
+    ):
+        out = _post_waiting_out_rate_limits(
+            "u", headers={}, json_body={}, timeout=1.0, rate_limit_max_wait=1000.0
+        )
+    assert out is seq[-1]
+    assert post.call_count == 3
+    assert sleep.call_count == 2  # slept before each retry, not after success
+
+
+def test_when_retry_after_header_present_then_that_delay_is_used():
+    seq = [_resp(429, headers={"retry-after": "8"}), _resp(200)]
+    with (
+        patch("src.agents.ollama_client.httpx.post", side_effect=seq),
+        patch("src.agents.ollama_client.time.sleep") as sleep,
+    ):
+        _post_waiting_out_rate_limits(
+            "u", headers={}, json_body={}, timeout=1.0, rate_limit_max_wait=1000.0
+        )
+    sleep.assert_called_once_with(8.0)
+
+
+def test_when_max_wait_is_zero_then_429_raises_immediately():
+    with (
+        patch("src.agents.ollama_client.httpx.post", return_value=_resp(429)),
+        patch("src.agents.ollama_client.time.sleep") as sleep,
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        _post_waiting_out_rate_limits(
+            "u", headers={}, json_body={}, timeout=1.0, rate_limit_max_wait=0.0
+        )
+    sleep.assert_not_called()
+
+
+def test_when_non_429_error_then_propagates_without_retry():
+    with (
+        patch("src.agents.ollama_client.httpx.post", return_value=_resp(500)) as post,
+        patch("src.agents.ollama_client.time.sleep") as sleep,
+        pytest.raises(httpx.HTTPStatusError),
+    ):
+        _post_waiting_out_rate_limits(
+            "u", headers={}, json_body={}, timeout=1.0, rate_limit_max_wait=1000.0
+        )
+    assert post.call_count == 1
+    sleep.assert_not_called()

--- a/training/tournament.py
+++ b/training/tournament.py
@@ -69,6 +69,11 @@ class TournamentConfig:
     # Per-action LLM timeout (s). A model exceeding this falls back to a random
     # legal move, so a slow/verbose model can't stall a whole game.
     action_timeout: float = 120.0
+    # Seconds to wait out HTTP 429 rate/usage limits (per call) before giving up.
+    # Ollama cloud throttles per-minute and on 5-hour session / 7-day weekly
+    # quotas; the client backs off and retries within this budget instead of
+    # playing a random move. Default 1 week covers the longest (weekly) reset.
+    rate_limit_max_wait: float = 604800.0
     # How to score a game with no sole survivor at the turn cap. "territory":
     # the board leader (most territories, tie-break by armies) is the winner, so
     # the leaderboard has signal even when 6p games don't eliminate to 1 within
@@ -175,6 +180,7 @@ def _build_config(raw: dict[str, Any]) -> TournamentConfig:
         max_turns=int(raw.get("max_turns", _MAX_TURNS)),
         negotiation_cadence=int(raw.get("negotiation_cadence", 1)),
         action_timeout=float(raw.get("action_timeout", 120.0)),
+        rate_limit_max_wait=float(raw.get("rate_limit_max_wait", 604800.0)),
         draw_resolution=str(raw.get("draw_resolution", "territory")),
     )
 
@@ -502,12 +508,14 @@ def build_negotiation_call_fn(
     player_id: int,
     player_configs: Sequence[PlayerConfig],
     base_url: str,
+    rate_limit_max_wait: float = 0.0,
 ) -> Callable | None:
     """Return a callable ``(player_id, prompt) -> dict | None`` for *player_id*.
 
     Routes negotiation prompts through ``call_ollama_for_negotiation`` (not the
     action-index path).  Strips a trailing ``/v1`` from *base_url* (Ollama cloud
-    compatibility).  The returned callable returns ``None`` on any LLM/HTTP error.
+    compatibility).  The returned callable returns ``None`` on any LLM/HTTP error;
+    HTTP 429 rate/usage limits are waited out (``rate_limit_max_wait``).
     """
     cfg = player_configs[player_id]
     root = base_url.removesuffix("/v1")
@@ -523,6 +531,7 @@ def build_negotiation_call_fn(
                 prompt=prompt,
                 max_message_tokens=_NEGOTIATION_MAX_TOKENS,
                 temperature=cfg.temperature,
+                rate_limit_max_wait=rate_limit_max_wait,
             )
         except Exception:  # any LLM/HTTP error → graceful no-op (docstring contract)
             return None
@@ -613,8 +622,17 @@ def _play_one_game(
     base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
     seats = build_seats(plan.assignment, config)
+    # timeout=0 disables the hard wall-clock cap so a call waiting out a 429
+    # rate/usage limit is never aborted into a random move; http_timeout bounds
+    # each individual HTTP attempt, and rate_limit_max_wait governs the wait.
     agents: list[LLMOpponent] = [
-        LLMOpponent(player_config=seat, timeout=config.action_timeout) for seat in seats
+        LLMOpponent(
+            player_config=seat,
+            timeout=0,
+            http_timeout=config.action_timeout,
+            rate_limit_max_wait=config.rate_limit_max_wait,
+        )
+        for seat in seats
     ]
 
     diplomacy_cfg = DiplomacyConfig(
@@ -623,7 +641,10 @@ def _play_one_game(
         negotiation_cadence=config.negotiation_cadence,
     )
 
-    per_player_fns = [build_negotiation_call_fn(i, seats, base_url) for i in range(_N_PLAYERS)]
+    per_player_fns = [
+        build_negotiation_call_fn(i, seats, base_url, config.rate_limit_max_wait)
+        for i in range(_N_PLAYERS)
+    ]
 
     def _routing_call_fn(player_id: int, prompt: str) -> dict | None:
         fn = per_player_fns[player_id]


### PR DESCRIPTION
## Problem
The full-cap smoke logged **3650 HTTP 429s → ~1728 actions (19%) fell back to random**, corrupting the strategy signal. Ollama cloud throttles on **per-minute, 5-hour session, and 7-day weekly** quotas and does **not** reliably send `Retry-After`/quota headers ([ollama#15663](https://github.com/ollama/ollama/issues/15663)). The client had no backoff — a 429 immediately degraded to a random move.

## Fix — pause and wait, never random, never error
- **`ollama_client._post_waiting_out_rate_limits`** wraps the action + negotiation POSTs. On 429: sleep (`Retry-After` if present, else capped exponential backoff + jitter) and retry until success or `rate_limit_max_wait` elapses. Non-429 errors propagate unchanged.
- **`LLMOpponent`**: split the hard wall-clock cap (`timeout`) from the per-HTTP-attempt bound (`http_timeout`). `timeout=0` disables the watchdog so a rate-limit wait isn't aborted into a random move. `rate_limit_max_wait` only added to call kwargs when `>0` → preserves the disabled-equivalence guarantee for the training path.
- **tournament**: `rate_limit_max_wait` config (default **1 week** — covers the weekly reset, so the run auto-pauses and resumes when the quota refreshes); seats run `timeout=0` + `http_timeout=action_timeout`. **`max_concurrency` 6→3** to stop provoking 429s (Ollama-cloud concurrent-model limits: Free 1, Pro 3, Max 10). Negotiation calls wait out 429 too.

Combined with the resumable ledger, a multi-hour (session) or multi-day (weekly) limit just pauses the run — no lost games, no random moves.

## Tests
- `_retry_after_seconds` (seconds + absent); `_post_waiting_out_rate_limits` (success no-sleep, 429→retry→success, Retry-After honored, max_wait=0 raises, non-429 propagates). All with `time.sleep` patched.
- Updated config assertions (max_concurrency); client/negotiation/disabled-equivalence/opponent suites pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)