### PR TITLE
feat(tournament): light (Low/Medium usage) cloud roster to stretch quota

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -65,14 +65,17 @@ strategies:
   - diplomat_coalition
 
 # ── 6-model roster (Ollama cloud, :cloud suffix convention) ─────────────────
+# Light roster — all Low/Medium usage-level to stretch the Ollama-cloud quota
+# (the prior glm-5.x / kimi / deepseek flagships were High/Heavy and drained the
+# 5h session quota in ~3 games). Context is a non-issue: prompts are ~2-4k
+# tokens, far under every model's 128-256k window.
 models:
-  - glm-5.2:cloud
-  - gemma4:31b-cloud      # replaced minimax-m3 (ignored think=False on cloud:
-                          # ~5389 tok / ~74s per action → timed out to random)
-  - glm-5.1:cloud
-  - kimi-k2.6:cloud
-  - deepseek-v4-flash:cloud
-  - qwen3.5:cloud
+  - gpt-oss:20b-cloud          # Low usage (lightest cloud model)
+  - gpt-oss:120b-cloud         # Medium
+  - gemma4:cloud               # Medium — fast, schema-honoring
+  - qwen3.5:cloud              # Medium — schema-honoring (256k)
+  - nemotron-3-super:cloud     # Medium — MoE, 12B active (efficient)
+  - minimax-m2.1:cloud         # Medium — instruct/interleaved-thinking
 
 # ── Sampling parameters (applied uniformly; per-player overrides in Cycle 8) ─
 temperature: 0.7

--- a/tests/test_108_tournament_config_loader.py
+++ b/tests/test_108_tournament_config_loader.py
@@ -26,12 +26,12 @@ _VALID_STRATEGIES = [
 ]
 
 _VALID_MODELS = [
-    "glm-5.2:cloud",
-    "gemma4:31b-cloud",
-    "glm-5.1:cloud",
-    "kimi-k2.6:cloud",
-    "deepseek-v4-flash:cloud",
+    "gpt-oss:20b-cloud",
+    "gpt-oss:120b-cloud",
+    "gemma4:cloud",
     "qwen3.5:cloud",
+    "nemotron-3-super:cloud",
+    "minimax-m2.1:cloud",
 ]
 
 

--- a/tests/test_tournament_config.py
+++ b/tests/test_tournament_config.py
@@ -14,12 +14,13 @@ CONFIG_PATH = pathlib.Path("config/tournament.yaml")
 
 REQUIRED_ROSTER = frozenset(
     {
-        "glm-5.2:cloud",
-        "gemma4:31b-cloud",  # replaced minimax-m3 (too slow on cloud → timed out to random)
-        "glm-5.1:cloud",
-        "kimi-k2.6:cloud",
-        "deepseek-v4-flash:cloud",
+        # Light roster (Low/Medium usage-level) — see config/tournament.yaml.
+        "gpt-oss:20b-cloud",
+        "gpt-oss:120b-cloud",
+        "gemma4:cloud",
         "qwen3.5:cloud",
+        "nemotron-3-super:cloud",
+        "minimax-m2.1:cloud",
     }
 )
 


### PR DESCRIPTION
## Why
The full-cap pilot stalled after ~3 games: the prior roster (glm-5.2, glm-5.1, kimi-k2.6, deepseek-v4-flash) are **High/Heavy** usage-level models that drained the Ollama-cloud **5-hour session quota** fast. Ollama bills **GPU-time** (per-model usage level), not tokens — lighter models = far more games per quota window. Context is irrelevant (prompts ~2-4k tokens vs 128-256k windows), so 256k+ isn't a selection criterion.

## New roster (all Low/Medium usage)
| Model | Usage |
|---|---|
| gpt-oss:20b-cloud | Low |
| gpt-oss:120b-cloud | Medium |
| gemma4:cloud | Medium |
| qwen3.5:cloud | Medium |
| nemotron-3-super:cloud | Medium (MoE 12B active) |
| minimax-m2.1:cloud | Medium |

`max_turns` kept at **200** (per request). Roster tests updated; preflight/assignment tests use self-fixtures, unaffected.

## Follow-up at relaunch
`nemotron-3-super` and `minimax-m2.1` are "thinking" models — verify they honor `format` with `think=False` and don't free-reason (the minimax-**m3** trap: 5389 tok/action). Quota currently exhausted so this couldn't be checked pre-merge; swap for `gpt-oss:120b` / `gemma4:31b` if they burn tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)