### PR TITLE
fix(tournament): drop token-burning models (gpt-oss, minimax-m2.1) from roster

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -70,12 +70,16 @@ strategies:
 # 5h session quota in ~3 games). Context is a non-issue: prompts are ~2-4k
 # tokens, far under every model's 128-256k window.
 models:
-  - gpt-oss:20b-cloud          # Low usage (lightest cloud model)
-  - gpt-oss:120b-cloud         # Medium
-  - gemma4:cloud               # Medium — fast, schema-honoring
-  - qwen3.5:cloud              # Medium — schema-honoring (256k)
-  - nemotron-3-super:cloud     # Medium — MoE, 12B active (efficient)
-  - minimax-m2.1:cloud         # Medium — instruct/interleaved-thinking
+  # All schema-honoring (measured short output / fast), so no free-reasoning
+  # token-burn. gpt-oss and minimax-m2.1 were dropped: as reasoning models they
+  # ignore think=False on cloud and emit 600-1100 tok/action (~9-24s) — the
+  # minimax-m3 trap. Roster leans to efficient instruct/MoE models.
+  - gemma4:cloud               # ~12 tok, 0.8s — gold
+  - gemma4:31b-cloud           # ~7 tok, 0.6s — gold
+  - nemotron-3-super:cloud     # ~8 tok, 1.9s — MoE 12B active
+  - qwen3.5:cloud              # ~189 tok, 5.1s — schema-honoring (256k)
+  - deepseek-v4-flash:cloud    # 0.7s — MoE 13B active
+  - kimi-k2.6:cloud            # 1.5s — schema-honoring
 
 # ── Sampling parameters (applied uniformly; per-player overrides in Cycle 8) ─
 temperature: 0.7

--- a/tests/test_108_tournament_config_loader.py
+++ b/tests/test_108_tournament_config_loader.py
@@ -26,12 +26,12 @@ _VALID_STRATEGIES = [
 ]
 
 _VALID_MODELS = [
-    "gpt-oss:20b-cloud",
-    "gpt-oss:120b-cloud",
     "gemma4:cloud",
-    "qwen3.5:cloud",
+    "gemma4:31b-cloud",
     "nemotron-3-super:cloud",
-    "minimax-m2.1:cloud",
+    "qwen3.5:cloud",
+    "deepseek-v4-flash:cloud",
+    "kimi-k2.6:cloud",
 ]
 
 

--- a/tests/test_tournament_config.py
+++ b/tests/test_tournament_config.py
@@ -14,13 +14,13 @@ CONFIG_PATH = pathlib.Path("config/tournament.yaml")
 
 REQUIRED_ROSTER = frozenset(
     {
-        # Light roster (Low/Medium usage-level) — see config/tournament.yaml.
-        "gpt-oss:20b-cloud",
-        "gpt-oss:120b-cloud",
+        # Schema-honoring, efficient roster — see config/tournament.yaml.
         "gemma4:cloud",
-        "qwen3.5:cloud",
+        "gemma4:31b-cloud",
         "nemotron-3-super:cloud",
-        "minimax-m2.1:cloud",
+        "qwen3.5:cloud",
+        "deepseek-v4-flash:cloud",
+        "kimi-k2.6:cloud",
     }
 )
 


### PR DESCRIPTION
## Why
Live per-model measurement on the light roster exposed the real burners — **gpt-oss** and **minimax-m2.1**. As reasoning models they ignore `think=False` on Ollama cloud and dump chains-of-thought into the action output:

| Model | avg tokens/action | latency | |
|---|---|---|---|
| gpt-oss:20b-cloud | ~1109 | 24.2s | 🔴 |
| gpt-oss:120b-cloud | ~729 | 8.6s | 🔴 |
| minimax-m2.1:cloud | ~619 | 4.6s | 🔴 |
| gemma4:cloud | ~12 | 0.8s | 🟢 |
| gemma4:31b-cloud | ~7 | 0.6s | 🟢 |
| nemotron-3-super:cloud | ~8 | 1.9s | 🟢 |
| qwen3.5:cloud | ~189 | 5.1s | 🟡 |
| deepseek-v4-flash / kimi-k2.6 | — | 0.7 / 1.5s | 🟢 |

**Lesson:** generation length matters as much as usage-level — a "Low"-usage model that free-reasons 1109 tokens is far worse than a "Medium" one emitting 8.

## New roster (all measured fast / schema-honoring)
`gemma4:cloud, gemma4:31b-cloud, nemotron-3-super:cloud, qwen3.5:cloud, deepseek-v4-flash:cloud, kimi-k2.6:cloud`. `max_turns` stays 200. Roster tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)