### PR TITLE
chore(tournament): n_games=300 for proper marginal statistics

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -13,7 +13,7 @@ seed: 42
 # ── Scale & concurrency ──────────────────────────────────────────────────────
 # Start with a 30-game pilot to validate the pipeline; scale to 1000+ games
 # for statistically significant strategy win-rates (Wilson CI).
-n_games: 30
+n_games: 300
 # Concurrent games. Ollama cloud limits concurrent models per plan (Free 1,
 # Pro 3, Max 10); exceeding it triggers HTTP 429. 3 matches Pro and keeps 429s
 # rare — raise only if your plan allows more concurrency.

--- a/tests/test_108_tournament_config_loader.py
+++ b/tests/test_108_tournament_config_loader.py
@@ -48,12 +48,12 @@ def test_when_tournament_config_loaded_then_seed_equals_42():
     assert cfg.seed == 42
 
 
-def test_when_tournament_config_loaded_then_n_games_equals_30():
-    """Criterion: n_games == 30 in the parsed TournamentConfig."""
+def test_when_tournament_config_loaded_then_n_games_is_positive():
+    """n_games must be a positive int (300-game run for proper marginal stats)."""
     from training.tournament import load_tournament_config
 
     cfg = load_tournament_config(CONFIG_PATH)
-    assert cfg.n_games == 30
+    assert cfg.n_games > 0
 
 
 def test_when_tournament_config_loaded_then_max_concurrency_is_positive():


### PR DESCRIPTION
## Why
The 30-game pilot answered directionally (`card_cycle_hunter` best 43%, `turtle_defensive` worst 0%) but with ±17% Wilson CIs — too wide to statistically separate the top 2 (card-cycle 43% vs diplomat 27%) or fully control for model strength.

**300 games** → ~±5% per-strategy CIs, each strategy played by every model enough times to average out model strength = publication-grade *marginal* strategy ranking.

`n_games: 30 → 300`. Test updated: `n_games` assertion is now "positive" instead of `== 30`. The `tourney300` run is already in flight (resumable, auto-pauses through the weekly Ollama quota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)