### PR TITLE
chore(tournament): cap run at n_games=100

### DIFF
--- a/config/tournament.yaml
+++ b/config/tournament.yaml
@@ -13,7 +13,7 @@ seed: 42
 # ── Scale & concurrency ──────────────────────────────────────────────────────
 # Start with a 30-game pilot to validate the pipeline; scale to 1000+ games
 # for statistically significant strategy win-rates (Wilson CI).
-n_games: 300
+n_games: 100
 # Concurrent games. Ollama cloud limits concurrent models per plan (Free 1,
 # Pro 3, Max 10); exceeding it triggers HTTP 429. 3 matches Pro and keeps 429s
 # rare — raise only if your plan allows more concurrency.


### PR DESCRIPTION
300 games would take ~2-3 weeks under the Ollama weekly quota — not feasible. **100 games** gives ~±10% per-strategy CIs and averages each strategy across all models — enough to separate the leader from the field. The `tourney300` run resumes from its existing ledger and stops at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)