### PR TITLE
feat(visualization): full-game JSON trace (prompts + responses + thinking)

### DIFF
--- a/src/agents/ollama_client.py
+++ b/src/agents/ollama_client.py
@@ -54,6 +54,36 @@ from src.utils.log import get_logger
 
 _log = get_logger("llm")
 
+# ── Optional call tracing (for visualization / full-game replay) ─────────────
+# When a sink list is installed via start_call_trace(), every action and
+# negotiation call appends a record with the exact prompt, the raw model
+# response (including the model's `thinking` trace when it emits one), and the
+# parsed result. Disabled by default (sink is None) → zero overhead and
+# byte-identical behavior. Intended for single-game tracing (calls are recorded
+# in the order they happen); not thread-safe across concurrent games.
+_CALL_TRACE: list[dict[str, Any]] | None = None
+
+
+def start_call_trace() -> list[dict[str, Any]]:
+    """Begin recording LLM calls; returns the list that will collect records."""
+    global _CALL_TRACE
+    _CALL_TRACE = []
+    return _CALL_TRACE
+
+
+def stop_call_trace() -> list[dict[str, Any]] | None:
+    """Stop recording and return the collected records (or None if not active)."""
+    global _CALL_TRACE
+    trace, _CALL_TRACE = _CALL_TRACE, None
+    return trace
+
+
+def _record_call(entry: dict[str, Any]) -> None:
+    """Append a trace record if tracing is active (no-op otherwise)."""
+    if _CALL_TRACE is not None:
+        _CALL_TRACE.append(entry)
+
+
 ENV_BASE_URL = "OLLAMA_BASE_URL"
 ENV_API_KEY = "OLLAMA_API_KEY"
 
@@ -287,7 +317,26 @@ def call_ollama_for_action_index(
     )
     elapsed = time.time() - t0
     data = response.json()
-    return _parse_index(data, legal_actions, model, elapsed)
+    idx = _parse_index(data, legal_actions, model, elapsed)
+    if _CALL_TRACE is not None:
+        message = data.get("message") or {}
+        chosen = None
+        if idx is not None and 0 <= idx < len(legal_actions):
+            chosen = legal_actions[idx]
+        _record_call(
+            {
+                "kind": "action",
+                "model": model,
+                "prompt": prompt,
+                "response": message.get("content"),
+                "thinking": message.get("thinking"),
+                "parsed_index": idx,
+                "chosen_action": chosen,
+                "latency_s": round(elapsed, 3),
+                "eval_count": data.get("eval_count"),
+            }
+        )
+    return idx
 
 
 def list_ollama_models(
@@ -448,7 +497,9 @@ def call_ollama_for_negotiation(
     """
     body = _build_negotiation_body(model, prompt, max_message_tokens, temperature, think)
     headers = {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
-    return _post_negotiation(f"{root}/api/chat", headers, body, timeout, rate_limit_max_wait)
+    return _post_negotiation(
+        f"{root}/api/chat", headers, body, timeout, rate_limit_max_wait, model, prompt
+    )
 
 
 def _build_negotiation_body(
@@ -477,6 +528,8 @@ def _post_negotiation(
     body: dict[str, Any],
     timeout: float,
     rate_limit_max_wait: float = 0.0,
+    model: str = "",
+    prompt: str = "",
 ) -> dict[str, Any] | None:
     try:
         resp = _post_waiting_out_rate_limits(
@@ -486,7 +539,22 @@ def _post_negotiation(
             timeout=timeout,
             rate_limit_max_wait=rate_limit_max_wait,
         )
-        return _parse_negotiation(resp.json())
+        data = resp.json()
+        parsed = _parse_negotiation(data)
+        if _CALL_TRACE is not None:
+            message = data.get("message") or {}
+            _record_call(
+                {
+                    "kind": "negotiation",
+                    "model": model,
+                    "prompt": prompt,
+                    "response": message.get("content"),
+                    "thinking": message.get("thinking"),
+                    "parsed": parsed,
+                    "eval_count": data.get("eval_count"),
+                }
+            )
+        return parsed
     except (_HttpxHTTPError, ValueError) as exc:
         _log.warning("call_ollama_for_negotiation error: %s", exc)
         return None

--- a/tests/test_game_trace.py
+++ b/tests/test_game_trace.py
@@ -1,0 +1,102 @@
+"""Tests for LLM call tracing (visualization/full-game replay).
+
+HTTP is mocked so no live Ollama is needed; the real client functions run so the
+trace-emit paths are exercised end to end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import src.agents.ollama_client as oc
+from src.env import RisikoEnv
+
+
+def _http_ok(content: str, thinking: str | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status.return_value = None
+    message: dict = {"content": content}
+    if thinking is not None:
+        message["thinking"] = thinking
+    resp.json.return_value = {"message": message, "eval_count": 7}
+    return resp
+
+
+def _obs_and_actions():
+    env = RisikoEnv(n_players=6)
+    obs, _ = env.reset(seed=1)
+    return obs, env.get_legal_actions()
+
+
+def test_when_tracing_active_then_action_call_records_prompt_response_thinking():
+    obs, legal = _obs_and_actions()
+    oc.start_call_trace()
+    try:
+        with patch(
+            "src.agents.ollama_client.httpx.post",
+            return_value=_http_ok('{"action_index": 0}', thinking="hold Australia"),
+        ):
+            idx = oc.call_ollama_for_action_index(
+                obs, legal, model="m:cloud", base_url="http://x/v1", api_key="k"
+            )
+    finally:
+        trace = oc.stop_call_trace()
+
+    assert idx == 0
+    assert trace is not None and len(trace) == 1
+    rec = trace[0]
+    assert rec["kind"] == "action"
+    assert rec["model"] == "m:cloud"
+    assert rec["prompt"]  # non-empty rendered prompt
+    assert rec["response"] == '{"action_index": 0}'
+    assert rec["thinking"] == "hold Australia"
+    assert rec["parsed_index"] == 0
+    assert rec["chosen_action"] == legal[0]
+
+
+def test_when_tracing_inactive_then_no_records_and_calls_unaffected():
+    obs, legal = _obs_and_actions()
+    oc.stop_call_trace()  # ensure sink is off
+    with patch(
+        "src.agents.ollama_client.httpx.post",
+        return_value=_http_ok('{"action_index": 0}'),
+    ):
+        idx = oc.call_ollama_for_action_index(
+            obs, legal, model="m:cloud", base_url="http://x/v1", api_key="k"
+        )
+    assert idx == 0
+    # A freshly started trace is empty → nothing leaked while inactive.
+    assert oc.start_call_trace() == []
+    oc.stop_call_trace()
+
+
+def test_when_tracing_active_then_negotiation_call_records_thinking_and_parsed():
+    content = (
+        '{"propose_alliance_with": [1], "accept_alliance_with": [], '
+        '"declare_war_on": [], "attack_priority": []}'
+    )
+    oc.start_call_trace()
+    try:
+        with patch(
+            "src.agents.ollama_client.httpx.post",
+            return_value=_http_ok(content, thinking="ally with player 1"),
+        ):
+            result = oc.call_ollama_for_negotiation(
+                root="http://x",
+                key="k",
+                model="n:cloud",
+                prompt="negotiate now",
+                max_message_tokens=64,
+            )
+    finally:
+        trace = oc.stop_call_trace()
+
+    assert isinstance(result, dict)
+    assert trace is not None and len(trace) == 1
+    rec = trace[0]
+    assert rec["kind"] == "negotiation"
+    assert rec["model"] == "n:cloud"
+    assert rec["prompt"] == "negotiate now"
+    assert rec["thinking"] == "ally with player 1"
+    assert rec["parsed"]["propose_alliance_with"] == [1]

--- a/visualization/trace_game.py
+++ b/visualization/trace_game.py
@@ -1,0 +1,120 @@
+"""Run one LLM tournament game and save a full JSON trace.
+
+Captures, for every LLM call in a single game, the exact prompt sent, the raw
+model response, the model's `thinking` trace (when it emits one), and the parsed
+action / negotiation — plus the final game result. Useful for visualization,
+debugging, and inspecting *why* a strategy won.
+
+Usage:
+    python -m visualization.trace_game                      # game 0, full game
+    python -m visualization.trace_game --game-index 3
+    python -m visualization.trace_game --max-turns 20       # short trace (cheap)
+    python -m visualization.trace_game --out visualization/my_game.json
+
+Output: visualization/game_trace_<run>_g<index>.json (unless --out given).
+
+Note: this runs a real game against Ollama and consumes quota. Use --max-turns
+to cap a quick sample; the default plays a full game (can be long + quota-heavy).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+from pathlib import Path
+from typing import Any
+
+import src.agents.ollama_client as _oc
+from src.utils.env import ensure_env_loaded
+from src.utils.log import get_logger
+from training.tournament import (
+    _play_one_game,
+    _to_serialisable,
+    build_game_plan,
+    load_tournament_config,
+)
+
+_log = get_logger("trace_game")
+
+
+def trace_one_game(
+    config_path: Path,
+    game_index: int = 0,
+    max_turns: int | None = None,
+) -> dict[str, Any]:
+    """Play one game with call tracing on; return a JSON-serialisable trace dict."""
+    ensure_env_loaded()
+    cfg = load_tournament_config(config_path)
+    if max_turns is not None:
+        cfg = dataclasses.replace(cfg, max_turns=max_turns)
+    plan = build_game_plan(cfg, game_index)
+
+    _log.info(
+        "tracing game %d (seed=%d, max_turns=%d) — assignment=%s",
+        game_index,
+        plan.seed,
+        cfg.max_turns,
+        plan.assignment,
+    )
+
+    _oc.start_call_trace()
+    try:
+        record = _play_one_game(plan, cfg)
+    finally:
+        calls = _oc.stop_call_trace() or []
+
+    return {
+        "run_id": cfg.name,
+        "game_index": game_index,
+        "seed": plan.seed,
+        "max_turns": cfg.max_turns,
+        "n_rounds": cfg.n_rounds,
+        "negotiation_cadence": cfg.negotiation_cadence,
+        "draw_resolution": cfg.draw_resolution,
+        "models": list(cfg.models),
+        "strategies": list(cfg.strategies),
+        "assignment": dict(plan.assignment),
+        "result": _to_serialisable(record.__dict__),
+        "n_calls": len(calls),
+        "calls": _to_serialisable(calls),
+    }
+
+
+def _default_out(trace: dict[str, Any]) -> Path:
+    return Path("visualization") / f"game_trace_{trace['run_id']}_g{trace['game_index']}.json"
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point: trace one game and write the JSON to disk."""
+    parser = argparse.ArgumentParser(description="Save a full JSON trace of one LLM game.")
+    parser.add_argument("--config", type=Path, default=Path("config/tournament.yaml"))
+    parser.add_argument("--game-index", type=int, default=0)
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        help="Override the per-game turn cap (use a small value for a quick, cheap sample).",
+    )
+    parser.add_argument("--out", type=Path, default=None, help="Output JSON path.")
+    args = parser.parse_args(argv)
+
+    trace = trace_one_game(args.config, args.game_index, args.max_turns)
+    out = args.out or _default_out(trace)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(trace, indent=2, ensure_ascii=False))
+
+    n_think = sum(1 for c in trace["calls"] if c.get("thinking"))
+    _log.info(
+        "saved %d calls (%d with thinking) → %s | winner=%s (%s)",
+        trace["n_calls"],
+        n_think,
+        out,
+        trace["result"].get("winner_strategy"),
+        trace["result"].get("winner_model"),
+    )
+    print(f"Saved game trace → {out}  ({trace['n_calls']} LLM calls, {n_think} with thinking)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Save a complete JSON trace of one LLM game under `visualization/` — every LLM call's **exact prompt**, **raw response**, **`thinking` trace** (when the model emits one), parsed action/negotiation, latency + tokens, plus the final result (winner, placement, alliances, betrayals).

## How
- `ollama_client`: optional module-level trace sink (`start_call_trace` / `stop_call_trace`). When active, action + negotiation calls append a record; **disabled by default → zero overhead, byte-identical behavior**. Single-game use (not thread-safe across concurrent games).
- `visualization/trace_game.py`:
  ```
  python -m visualization.trace_game                 # game 0, full game
  python -m visualization.trace_game --max-turns 20  # quick, cheap sample
  python -m visualization.trace_game --game-index 3 --out visualization/g3.json
  ```
  Writes `visualization/game_trace_<run>_g<index>.json`.

## Tests
HTTP mocked so the real trace-emit paths run: action + negotiation capture prompt/response/thinking/parsed; inactive sink records nothing. ruff clean.

Note: producing a real trace runs a live game and consumes Ollama quota — use `--max-turns` for a small sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)