### PR TITLE
fix(experiment): three silent bugs that made the tournament uninterpretable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,11 @@ test_output.txt
 # run is results/tournament/tourney300/ (100 games).
 results/tournament/pilot*/
 results/tournament/smoke*/
+
+# Aborted tournament runs, kept on disk for reference but never published: their
+# numbers come from code with a bug we have since fixed.
+results/tournament/*ABORTED*/
+
+# One-off diagnostic traces (the A/B that exposed the self-leader bug). The finding
+# lives in tests/test_seat_confound.py; the raw dumps are 700 KB each.
+visualization/game_trace_fixed*.json

--- a/src/agents/diplomacy.py
+++ b/src/agents/diplomacy.py
@@ -121,9 +121,22 @@ class DiplomacyState:
         raw = _BASE_TRUST + bonus - self.grudge_score(a, b, now)
         return max(0.0, min(1.0, raw))
 
-    def leader(self, territory_owner: Sequence[int]) -> int:
-        """Player with the most territories; lowest id breaks ties deterministically."""
+    def leader(self, territory_owner: Sequence[int]) -> int | None:
+        """Player with the most territories, or ``None`` when nobody is ahead.
+
+        A tie used to be broken by lowest player id. That looks harmless and is not:
+        the prompt announces the result as ``Leader (most territories): Player N``, and
+        the models act on that line. At turn 0 every player holds an equal share, so the
+        tie-break crowned **seat 0** in every single game — and the other seats duly
+        declared war on it. Measured on an identical board, adding that line moved the
+        share of turn-0 war declarations aimed at seat 0 from 1-in-6 to 4-in-6.
+
+        A tie means there is no leader. Say so, and let the models read the board.
+        """
         counts = np.bincount(territory_owner)
+        top = int(counts.max())
+        if int((counts == top).sum()) > 1:
+            return None
         return int(np.argmax(counts))
 
 

--- a/src/agents/negotiation.py
+++ b/src/agents/negotiation.py
@@ -173,7 +173,19 @@ class NegotiationOrchestrator:
         return result
 
     def _prompt_for(self, speaker: int, obs: dict[str, Any]) -> str:
-        """Build the negotiation prompt for this speaker."""
+        """Build the negotiation prompt for this speaker.
+
+        Nobody is ever told that the leader is themselves. The action prompt has always
+        guarded this (``build_diplomacy_note``: ``leader if leader != player else None``);
+        the negotiation prompt did not, so in 1 traced negotiation out of 6 a model read
+        ``Leader (most territories): Player N`` with N being its own seat.
+
+        That is not a cosmetic slip. The coalition strategy's whole instruction is
+        "gang up on the leader" — pointed at itself, it is degenerate, and the logs show
+        exactly that: the diplomat, told it was the leader, declared war on a random
+        player and proposed no alliances at all. The aggressor, in the same spot,
+        declared war on a player and offered it an alliance in the same reply.
+        """
         allies = sorted(p for p in self._profiles if self._state.are_allied(speaker, p))
         owners = obs.get("territory_owner", [])
         leader = self._state.leader(owners) if len(owners) > 0 else None
@@ -181,7 +193,7 @@ class NegotiationOrchestrator:
             player_id=speaker,
             board=obs,
             allies=allies,
-            leader=leader,
+            leader=leader if leader != speaker else None,
             grudges={},
             max_chars=self._cfg.max_message_tokens * 5,
         )

--- a/src/agents/negotiation_prompt.py
+++ b/src/agents/negotiation_prompt.py
@@ -2,11 +2,19 @@
 
 Kept in a separate module from action_prompt.py so that the action-selection
 path is untouched and issue #102 can extend action_prompt.py without conflict.
+
+The board summary used to read ``board["territories"]`` — a key the environment's
+observation has never had. It exposes ``territory_owner`` and ``armies`` as parallel
+arrays instead, so the lookup silently returned ``{}`` and the ``## Territories``
+section rendered empty in every negotiation, in every game. The models were choosing
+who to ally with and who to betray while unable to see the board.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from src.utils.constants import CONTINENTS, NUM_TERRITORIES, TERRITORY_NAMES
 
 __all__ = ["render_negotiation_prompt"]
 
@@ -19,22 +27,100 @@ def render_negotiation_prompt(
     grudges: dict[int, list[str]],
     max_chars: int,
 ) -> str:
-    """Render a negotiation prompt; capped at *max_chars* characters."""
-    parts = [
-        f"# Risiko Negotiation — Player {player_id}",
-        _render_territory_summary(board),
-        _render_diplomacy_context(allies, leader, grudges),
-    ]
+    """Render a negotiation prompt; capped at *max_chars* characters.
+
+    Args:
+        player_id: The seat being asked to negotiate.
+        board: An environment observation (``territory_owner`` / ``armies`` arrays).
+        allies: Seats currently allied with *player_id*.
+        leader: Seat holding the most territories, if known.
+        grudges: Seat → list of grievances against it.
+        max_chars: Hard cap on the rendered prompt.
+
+    Returns:
+        The prompt text.
+    """
+    header = f"# Risiko Negotiation — Player {player_id}"
+    diplomacy = _render_diplomacy_context(allies, leader, grudges)
+
+    # The budget is tight (max_message_tokens * 5 — 640 chars by default), and a naive
+    # "join everything then slice" drops whatever sits last. That is how the first fix
+    # to this file silently truncated the Diplomacy block mid-word, so the models could
+    # see the board but not who they were allied with or who was leading.
+    # Diplomacy is short and load-bearing: reserve it, and let the board take the rest,
+    # shedding whole lines from the least important end.
+    reserved = len(header) + len(diplomacy) + 4  # 4 = the two "\n\n" separators
+    board_budget = max_chars - reserved
+    board_summary = _fit_lines(_render_board_summary(board, player_id), board_budget)
+
+    parts = [header, board_summary, diplomacy] if board_summary else [header, diplomacy]
+    # Hard cap. Reserving diplomacy above means this slice normally has nothing left to
+    # cut; it only bites when max_chars is smaller than the header itself.
     return "\n\n".join(parts)[:max_chars]
 
 
-def _render_territory_summary(board: dict[str, Any]) -> str:
-    territories = board.get("territories", {})
-    lines = ["## Territories"]
-    lines.extend(
-        f"  {name}: P{info.get('owner', '?')} a{info.get('armies', '?')}"
-        for name, info in territories.items()
-    )
+def _fit_lines(text: str, budget: int) -> str:
+    """Trim *text* to *budget* characters, dropping whole lines from the end.
+
+    Cutting mid-line would hand the model a half-rendered board row, which reads as a
+    corrupt fact rather than a missing one.
+    """
+    if budget <= 0:
+        return ""
+    lines = text.split("\n")
+    kept: list[str] = []
+    used = 0
+    for line in lines:
+        cost = len(line) + 1
+        if used + cost > budget:
+            break
+        kept.append(line)
+        used += cost
+    return "\n".join(kept) if len(kept) > 1 else ""
+
+
+def _render_board_summary(board: dict[str, Any], player_id: int) -> str:
+    """Summarise the board per player, then per continent.
+
+    Deliberately a summary and not the 42-line dump the action prompt uses: a
+    negotiator needs to know who is strong, who is weak, and who is close to a
+    continent bonus — not the army count of every single territory. Keeping it
+    compact also keeps the negotiation call cheap, and it is called once per player
+    per round.
+    """
+    owners = board.get("territory_owner")
+    armies = board.get("armies")
+    if owners is None or armies is None or len(owners) == 0:
+        return "## Board\n  (unavailable)"
+
+    n_players = int(board.get("n_players", max(int(o) for o in owners) + 1))
+    held: dict[int, list[int]] = {p: [] for p in range(n_players)}
+    for territory in range(min(NUM_TERRITORIES, len(owners))):
+        held.setdefault(int(owners[territory]), []).append(territory)
+
+    lines = ["## Board"]
+    lines.append("  Standings (territories · armies):")
+    ranked = sorted(held.items(), key=lambda kv: -len(kv[1]))
+    for seat, territories in ranked:
+        if not territories:
+            continue
+        army_total = sum(int(armies[t]) for t in territories)
+        marker = " ← you" if seat == player_id else ""
+        lines.append(f"    P{seat}: {len(territories)} territories · {army_total} armies{marker}")
+
+    lines.append("  Continents (holder of most territories, and whether it is complete):")
+    for continent, members in CONTINENTS.items():
+        counts: dict[int, int] = {}
+        for territory in members:
+            counts[int(owners[territory])] = counts.get(int(owners[territory]), 0) + 1
+        top_seat, top_count = max(counts.items(), key=lambda kv: kv[1])
+        status = "COMPLETE" if top_count == len(members) else f"{top_count}/{len(members)}"
+        lines.append(f"    {continent}: P{top_seat} {status}")
+
+    yours = held.get(player_id, [])
+    if yours:
+        names = ", ".join(f"{TERRITORY_NAMES[t]}(a{int(armies[t])})" for t in yours)
+        lines.append(f"  Your territories: {names}")
     return "\n".join(lines)
 
 

--- a/src/agents/strategies.py
+++ b/src/agents/strategies.py
@@ -1,9 +1,38 @@
 """Strategy catalog for Risiko RL — pure data module, no I/O or LLM calls.
 
-Defines the six research-grounded Risiko strategies, each with a board-play
-hint, a diplomatic posture, and helpers to build a ``PlayerConfig`` from a
-strategy. This is the single source of truth consumed by Cycle 8's tournament
-driver.
+Defines the six Risiko strategies, each with a board-play hint, a diplomatic posture,
+and helpers to build a ``PlayerConfig`` from a strategy. This is the single source of
+truth consumed by the tournament driver.
+
+Provenance
+----------
+These are not invented. They are the strategies human players actually advocate, taken
+from the mainstream Risk strategy literature, so the tournament measures received wisdom
+rather than a designer's guesses:
+
+* ``australia_lock`` — the single most-repeated tip in every guide: Australia is the
+  only continent defensible by fortifying one border (Indonesia/Siam).
+  https://remptongames.com/2023/01/15/the-ultimate-risk-strategy-guide-top-tips-to-win-more-at-risk/
+  https://bargames101.com/risk-strategy/
+  The same guides carry the counter-argument our data confirms: "everybody tends to try
+  to gun for that continent early, which could defeat the entire purpose", and it is
+  "easy to get trapped in Australia".
+* ``south_america_lock`` — the runner-up recommendation: four territories, two borders,
+  a bridge to both Africa and North America.
+* ``aggressive_blitz`` — eliminate the weak to take their cards and snowball.
+* ``turtle_defensive`` — the passive line. Included as a baseline to beat, not because
+  anyone recommends it.
+* ``card_cycle_hunter`` — the "technical" line. Set values escalate (4, 6, 8, 10, 12, 15,
+  then +5), and a card is drawn only if at least one territory was captured that turn, so
+  guaranteeing one conquest per turn compounds. https://en.wikipedia.org/wiki/Risk_(game)
+* ``diplomat_coalition`` — table folklore, and explicit in the guides: "when somebody is
+  clearly winning, players have a tendency to build alliances against them"; alliances
+  form around a common enemy.
+  https://remptongames.com/2023/01/15/the-ultimate-risk-strategy-guide-top-tips-to-win-more-at-risk/
+
+A caveat worth carrying: the LLMs playing these strategies were trained on this very
+literature. A result like "the Australia lock underperforms" may therefore say as much
+about what the models have *read* about Australia as about the board itself.
 """
 
 from __future__ import annotations

--- a/src/multi_agent.py
+++ b/src/multi_agent.py
@@ -472,5 +472,6 @@ class DiplomacyRunner(MultiAgentRunner):
         territory_owner = obs.get("territory_owner", np.array([], dtype=np.int32))
         leader: int | None = None
         if len(territory_owner) > 0:
-            leader = int(self._state.leader(territory_owner))
+            # None when the board is tied — there is no leader to gang up on.
+            leader = self._state.leader(territory_owner)
         return DiplomacyContext(state=self._state, acting_player=player, leader=leader)

--- a/tests/test_diplomacy_state.py
+++ b/tests/test_diplomacy_state.py
@@ -149,17 +149,28 @@ def test_when_grudge_score_evaluated_at_same_turn_as_attack_no_decay_applied():
 
 
 # ---------------------------------------------------------------------------
-# Criterion: leader() breaks ties by lowest player id;
+# Criterion: leader() names a leader only when there is one;
 #            trust() is monotonic in grudge score
 # ---------------------------------------------------------------------------
 
 
-def test_when_players_tied_in_territories_then_leader_returns_lowest_player_id():
-    """Tie broken by lowest player id (deterministic)."""
+def test_when_players_tied_in_territories_then_there_is_no_leader():
+    """A tie has no leader.
+
+    This used to break ties by lowest player id "for determinism". Determinism was
+    never the problem — the problem is that the result is announced to the models as
+    ``Leader (most territories): Player N`` and they act on it. Every game starts with
+    every player on an equal share, so the tie-break crowned seat 0 in every single
+    game and the table duly ganged up on it. Returning None is just as deterministic
+    and does not invent a fact.
+
+    (Resolving a *drawn game* still needs a winner; that is ``_territory_leader`` in
+    training/tournament.py, which keeps its tie-break.)
+    """
     # Players 0 and 1 each own 3 territories out of 6.
     territory_owner = [0, 1, 0, 1, 0, 1]
     state = _make_state()
-    assert state.leader(territory_owner) == 0
+    assert state.leader(territory_owner) is None
 
 
 def test_when_one_player_dominates_then_leader_returns_dominant_player():
@@ -174,11 +185,11 @@ def test_when_single_player_owns_all_then_leader_is_that_player():
     assert state.leader(territory_owner) == 5
 
 
-def test_when_three_way_tie_then_leader_is_lowest_id():
-    """With three players tied, the lowest id (0) is returned."""
+def test_when_three_way_tie_then_there_is_still_no_leader():
+    """Any tie at the top means nobody is ahead — not even a three-way one."""
     territory_owner = [0, 1, 2, 0, 1, 2]  # 2 territories each
     state = _make_state()
-    assert state.leader(territory_owner) == 0
+    assert state.leader(territory_owner) is None
 
 
 def test_when_no_attack_history_then_trust_is_nonnegative():

--- a/tests/test_negotiation_client.py
+++ b/tests/test_negotiation_client.py
@@ -69,14 +69,20 @@ def _call(**overrides):
 
 
 def _minimal_board() -> dict:
-    return {
-        "territories": {
-            "Alaska": {"owner": 0, "armies": 3},
-            "Kamchatka": {"owner": 1, "armies": 5},
-        },
-        "reinforcements_remaining": 3,
-        "trade_count": 2,
-    }
+    """A board shaped like a REAL environment observation.
+
+    This fixture used to invent a shape the environment never produces —
+    ``{"territories": {"Alaska": {...}}}`` — and the prompt renderer was written to
+    match the fixture. Both agreed with each other and neither agreed with reality:
+    the renderer's lookup missed, so the board section of every negotiation prompt
+    rendered empty in every real game, while this test went on passing.
+
+    Take the observation straight from the env so the fixture cannot drift again.
+    """
+    from src.env import RisikoEnv
+
+    obs, _ = RisikoEnv(n_players=6).reset(seed=7)
+    return dict(obs)
 
 
 # ===========================================================================
@@ -327,17 +333,57 @@ def test_when_action_index_function_inspected_then_no_diplomacy_kwargs_were_adde
 
 
 def test_when_render_called_then_output_includes_territory_information():
-    """Prompt must include board/territory information."""
+    """Prompt must include board/territory information.
+
+    Asserts on the *content*, not on the word "territory" appearing somewhere: the
+    previous version passed against a prompt whose board section was empty.
+    """
+    from src.utils.constants import TERRITORY_NAMES
+
+    board = _minimal_board()
     result = render_negotiation_prompt(
         player_id=0,
-        board=_minimal_board(),
+        board=board,
         allies=[],
         leader=None,
         grudges={},
-        max_chars=2000,
+        max_chars=4000,
     )
-    assert isinstance(result, str) and len(result) > 0
-    assert any(tok in result for tok in ("Alaska", "Kamchatka", "territories", "territory"))
+
+    # A standing line for every seat, with real counts.
+    for seat in range(6):
+        assert f"P{seat}:" in result, f"no standings line for seat {seat}"
+    # Every continent, so a negotiator can see who is close to a bonus.
+    assert "Australia:" in result and "Asia:" in result
+    # And at least one real territory this player actually holds.
+    owned = [t for t in range(42) if int(board["territory_owner"][t]) == 0]
+    assert any(TERRITORY_NAMES[t] in result for t in owned)
+
+
+def test_when_budget_is_tight_then_diplomacy_survives_and_the_board_is_trimmed():
+    """The char cap must never cost the model its allies or the leader.
+
+    The board summary is long and the budget is small (max_message_tokens * 5). A naive
+    "join everything, then slice" drops whatever sits last — which silently truncated the
+    Diplomacy block mid-word, leaving the models able to see the board but not who they
+    were allied with. Diplomacy is reserved; the board sheds whole lines instead.
+    """
+    result = render_negotiation_prompt(
+        player_id=0,
+        board=_minimal_board(),
+        allies=[2, 4],
+        leader=3,
+        grudges={},
+        max_chars=400,  # deliberately too small for board + diplomacy together
+    )
+
+    assert "Allies: [2, 4]" in result
+    assert "Leader (most territories): Player 3" in result
+    assert len(result) <= 400
+    # And nothing is cut mid-line: every board row is whole.
+    for line in result.split("\n"):
+        if line.strip().startswith("P") and "territories" in line:
+            assert "armies" in line, f"board row truncated mid-line: {line!r}"
 
 
 def test_when_render_called_with_allies_then_output_references_ally():

--- a/tests/test_seat_confound.py
+++ b/tests/test_seat_confound.py
@@ -1,0 +1,165 @@
+"""Guards against the three design bugs that made the first tournament uninterpretable.
+
+All three were silent: nothing crashed, nothing logged, and the numbers looked fine.
+They were only visible by cross-tabulating the published ledger and reading the prompts
+the models actually received.
+
+1. **Strategy was pinned to a seat.** The tournament permuted models across strategies
+   but never permuted strategies across seats, so seat *i* played ``strategies[i]`` in
+   all 100 games. "Win rate by strategy" and "win rate by seat" were then the same
+   number, and no analysis could separate them.
+
+2. **A tie invented a leader.** ``DiplomacyState.leader`` broke ties by lowest player
+   id. At turn 0 every player holds an equal share, so the prompt announced
+   ``Leader: Player 0`` in every game — and the models act on that line. Measured on an
+   identical board, adding it moved the share of turn-0 war declarations aimed at seat 0
+   from 1-in-6 to 4-in-6. Since seat 0 was always the same strategy (bug 1), one
+   strategy was ganged up on at the start of every single game.
+
+3. **A player could be told it was its own leader.** The action prompt always guarded
+   this; the negotiation prompt did not. One traced negotiation in six named the reader
+   as the leader. The coalition strategy's entire instruction is "gang up on the leader"
+   — pointed at itself, it is degenerate, and the logs show it: the diplomat, told it
+   led, declared war on a random player and proposed no alliances at all; the aggressor,
+   in the same spot, declared war on a player and offered it an alliance in the same
+   reply. Found by a viewer, not by us.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.agents.diplomacy import DiplomacyState
+from training.tournament import (
+    assign_strategies_to_seats,
+    build_game_plan,
+    build_seats,
+    load_tournament_config,
+)
+
+CONFIG = Path("config/tournament.yaml")
+
+pytestmark = pytest.mark.skipif(not CONFIG.is_file(), reason="tournament config not on disk")
+
+
+# ── Bug 1: strategy must not be pinned to a seat ─────────────────────────────
+def test_every_strategy_visits_every_seat_across_a_run() -> None:
+    config = load_tournament_config(CONFIG)
+    n_games = 100
+
+    seen: dict[str, set[int]] = {s: set() for s in config.strategies}
+    for game in range(n_games):
+        for seat, strategy in enumerate(build_game_plan(config, game).seat_order):
+            seen[strategy].add(seat)
+
+    for strategy, seats in seen.items():
+        assert seats == set(range(6)), f"{strategy} never sat in seats {set(range(6)) - seats}"
+
+
+def test_seat_assignment_is_roughly_uniform() -> None:
+    """No strategy may be over-represented in any seat — that is the whole point."""
+    config = load_tournament_config(CONFIG)
+    n_games = 600
+    expected = n_games / 6  # 100 per (strategy, seat) cell
+
+    counts: Counter[tuple[str, int]] = Counter()
+    for game in range(n_games):
+        for seat, strategy in enumerate(build_game_plan(config, game).seat_order):
+            counts[(strategy, seat)] += 1
+
+    for (strategy, seat), n in counts.items():
+        # Generous band: this catches "pinned to a seat", not sampling noise.
+        assert 0.6 * expected < n < 1.4 * expected, (
+            f"{strategy} sat in seat {seat} {n} times out of {n_games} (expected ~{expected:.0f})"
+        )
+
+
+def test_seat_order_is_a_permutation_not_a_resample() -> None:
+    order = assign_strategies_to_seats(["a", "b", "c", "d", "e", "f"], seed=3)
+    assert sorted(order) == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_seat_order_is_deterministic_for_a_seed() -> None:
+    strategies = ["a", "b", "c", "d", "e", "f"]
+    assert assign_strategies_to_seats(strategies, seed=9) == assign_strategies_to_seats(
+        strategies, seed=9
+    )
+
+
+def test_seat_order_is_independent_of_the_model_assignment() -> None:
+    """Both permutations derive from the same per-game seed; they must not move together.
+
+    If they shared an RNG stream, a strategy landing on seat 0 would also always draw the
+    same model — trading one confound for another.
+    """
+    config = load_tournament_config(CONFIG)
+    pairs = set()
+    for game in range(60):
+        plan = build_game_plan(config, game)
+        pairs.add((plan.seat_order[0], plan.assignment[plan.seat_order[0]]))
+    # Seat 0's strategy is paired with many different models across the run.
+    assert len(pairs) > 12, f"seat 0 strategy/model pairs are too correlated: {len(pairs)}"
+
+
+def test_build_seats_honours_the_per_game_seat_order() -> None:
+    config = load_tournament_config(CONFIG)
+    plan = build_game_plan(config, 0)
+
+    seats = build_seats(plan.assignment, config, seat_order=plan.seat_order)
+
+    for i, strategy in enumerate(plan.seat_order):
+        assert seats[i].model == plan.assignment[strategy]
+        assert seats[i].player_id == i
+
+
+# ── Bug 2: a tie has no leader ───────────────────────────────────────────────
+def test_a_tied_board_has_no_leader() -> None:
+    """Turn 0 is always a tie. Crowning seat 0 there is an artefact, not a fact."""
+    state = DiplomacyState()
+    tied = np.array([p for p in range(6) for _ in range(7)])  # 7 territories each
+
+    assert state.leader(tied) is None
+
+
+def test_a_clear_leader_is_still_reported() -> None:
+    state = DiplomacyState()
+    owners = np.array([2] * 20 + [p for p in range(6) for _ in range(3)] + [0, 1, 3, 4])
+
+    assert state.leader(owners) == 2
+
+
+# ── Bug 3: nobody is ever told that the leader is themselves ─────────────────
+def test_a_player_is_never_told_it_is_its_own_leader() -> None:
+    """The negotiation prompt must not name the reader as the leader.
+
+    The action prompt has always guarded this; the negotiation prompt did not, so one
+    traced negotiation in six read ``Leader (most territories): Player N`` with N being
+    the reader's own seat. The coalition strategy is "gang up on the leader" — aimed at
+    itself it is degenerate, and the logs bear that out: the diplomat, told it led,
+    declared war on a random player and proposed no alliances at all.
+    """
+    from src.agents.negotiation import NegotiationOrchestrator
+    from src.agents.player_config import DEFAULT_6P_PROFILES
+    from src.agents.reputation import ReputationBook
+    from src.config import DiplomacyConfig
+
+    # Seat 3 leads the board outright.
+    owners = np.array([3] * 20 + [p for p in range(6) for _ in range(3)] + [0, 1, 4, 5])
+    obs = {"territory_owner": owners, "armies": np.ones(42, dtype=int), "n_players": 6}
+
+    orchestrator = NegotiationOrchestrator(
+        state=DiplomacyState(),
+        reputation=ReputationBook(),
+        cfg=DiplomacyConfig(enabled=True, n_rounds=1),
+        profiles=DEFAULT_6P_PROFILES,
+    )
+
+    leader_prompt = orchestrator._prompt_for(3, obs)  # the leader itself
+    other_prompt = orchestrator._prompt_for(0, obs)  # everyone else
+
+    assert "Leader" not in leader_prompt, "the leader was told it is the leader"
+    assert "Leader (most territories): Player 3" in other_prompt, "others must still see it"

--- a/training/tournament.py
+++ b/training/tournament.py
@@ -89,11 +89,18 @@ class TournamentConfig:
 
 @dataclass(frozen=True)
 class GamePlan:
-    """Per-game execution plan derived from TournamentConfig."""
+    """Per-game execution plan derived from TournamentConfig.
+
+    ``seat_order`` is the strategies permuted onto the six seats for this game. It
+    exists because the tournament used to permute only the *models*, leaving each
+    strategy nailed to a fixed seat for all 100 games — so "win rate by strategy" and
+    "win rate by seat" were the same number, and the two could not be told apart.
+    """
 
     game_index: int
     seed: int
     assignment: dict[str, str]
+    seat_order: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -281,7 +288,27 @@ def build_game_plan(config: TournamentConfig, game_index: int) -> GamePlan:
     assignment = assign_strategies_to_models(
         list(config.strategies), list(config.models), seed=per_game_seed
     )
-    return GamePlan(game_index=game_index, seed=per_game_seed, assignment=assignment)
+    seat_order = assign_strategies_to_seats(list(config.strategies), seed=per_game_seed)
+    return GamePlan(
+        game_index=game_index,
+        seed=per_game_seed,
+        assignment=assignment,
+        seat_order=seat_order,
+    )
+
+
+def assign_strategies_to_seats(strategies: Sequence[str], *, seed: int) -> tuple[str, ...]:
+    """Return the strategies permuted onto seats for one game.
+
+    Seat position is not free: turn order differs, and the negotiation prompt names a
+    board leader that the models act on. Pinning a strategy to a seat therefore
+    confounds the two. Deriving the permutation from a *different* RNG stream than the
+    model assignment keeps the two permutations independent — otherwise a strategy that
+    lands on seat 0 would also always draw the same model.
+    """
+    rng = np.random.default_rng(seed + 1_000_003)  # a prime offset: distinct stream
+    perm = rng.permutation(len(strategies))
+    return tuple(strategies[i] for i in perm)
 
 
 # ---------------------------------------------------------------------------
@@ -471,14 +498,22 @@ class _DiplomacyWiring:
 def build_seats(
     assignment: dict[str, str],
     config: TournamentConfig,
+    seat_order: Sequence[str] | None = None,
 ) -> list[PlayerConfig]:
-    """Return one PlayerConfig per slot, in strategy-list order.
+    """Return one PlayerConfig per seat.
 
-    ``assignment`` is a bijection {strategy_slug: model}.  Slot *i* receives
-    the model for ``config.strategies[i]``.  The ``strategy_hint`` and posture
-    levers (trust_propensity, vengefulness) come from the strategy catalog via
-    ``to_player_config``.
+    Args:
+        assignment: Bijection {strategy_slug: model}.
+        config: The tournament config (sampling params, and the default seat order).
+        seat_order: Strategies in seat order for this game. Defaults to
+            ``config.strategies`` — which is what the tournament used to do for every
+            game, pinning each strategy to one seat and confounding strategy with seat
+            position. The tournament now passes ``plan.seat_order``.
+
+    Returns:
+        One ``PlayerConfig`` per seat, in seat order.
     """
+    order = list(seat_order) if seat_order else list(config.strategies)
     return [
         to_player_config(
             get_strategy(strategy),
@@ -487,7 +522,7 @@ def build_seats(
             top_p=config.top_p,
             model=assignment[strategy],
         )
-        for i, strategy in enumerate(config.strategies)
+        for i, strategy in enumerate(order)
     ]
 
 
@@ -626,7 +661,7 @@ def _play_one_game(
     ensure_env_loaded()
     base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
 
-    seats = build_seats(plan.assignment, config)
+    seats = build_seats(plan.assignment, config, seat_order=plan.seat_order)
     # timeout=0 disables the hard wall-clock cap so a call waiting out a 429
     # rate/usage limit is never aborted into a random move; http_timeout bounds
     # each individual HTTP attempt, and rate_limit_max_wait governs the wait.
@@ -687,12 +722,16 @@ def _play_one_game(
             resolution = "territory_cap"
 
     winner_strategy: str | None = None
+    # The seat order is per-game now: read the winner's strategy off the seats that
+    # actually played, never off the static config list.
+    order = list(plan.seat_order) if plan.seat_order else list(config.strategies)
+
     winner_model: str | None = None
     if winner is not None:
-        winner_strategy = list(config.strategies)[winner]
+        winner_strategy = order[winner]
         winner_model = plan.assignment.get(winner_strategy)
 
-    seat_strategies = {str(i): list(config.strategies)[i] for i in range(_N_PLAYERS)}
+    seat_strategies = {str(i): order[i] for i in range(_N_PLAYERS)}
     seat_models = {str(i): seats[i].model for i in range(_N_PLAYERS)}
 
     final_ranking = _final_ranking(env.state, result.elimination_order)


### PR DESCRIPTION
Stacked on #146. None of these bugs crashed, logged, or looked wrong — the published 100-game numbers were produced with all three active.

## 1. Strategy was pinned to a seat

`build_game_plan` permuted **models** across strategies but never permuted **strategies** across seats. Seat *i* played `strategies[i]` in all 100 games, so "win rate by strategy" and "win rate by seat" were literally the same number — 14 / 11 / 19 / 4 / 25 / 27 reads identically down either axis. No analysis could separate them.

Fixed: the seat order is permuted per game, from a **distinct RNG stream** — sharing one would mean a strategy landing on seat 0 also always drew the same model, trading one confound for another.

## 2. A tie invented a leader

`DiplomacyState.leader` broke ties by lowest player id "for determinism". Determinism was never the problem: the result is announced to the models as `Leader (most territories): Player N`, and **they act on that line**. Every game starts with all six players on 7 territories, so the tie-break crowned **seat 0 in every single game**.

Measured on an identical board, adding that one line moved the share of turn-0 war declarations aimed at seat 0 **from 1-in-6 to 4-in-6**.

Combined with bug 1, one fixed strategy was ganged up on at the start of every game — and it was `australia_lock`, the strategy we published as *"no better than random"*.

Fixed: a tie returns `None`. Resolving a *drawn game* still needs a winner; that is `_territory_leader`, which keeps its tie-break.

## 3. A player could be told it was its own leader

The action prompt has always guarded this. The negotiation prompt did not — **one traced negotiation in six** named the reader as the leader.

The coalition strategy's entire instruction is *"gang up on the leader"*. Pointed at itself it is degenerate, and the logs show exactly that: the diplomat, told it led, **declared war on a random player and proposed no alliances at all**; the aggressor, in the same spot, declared war on a player and offered it an alliance in the same reply.

**Found by a viewer, not by us.**

## Also fixed, same investigation

**Negotiation was board-blind.** `negotiation_prompt` read `board["territories"]` — a key the environment has never had (it exposes `territory_owner` / `armies` as arrays). The lookup silently returned `{}` and the board section rendered **empty in every negotiation of every game**: 114 characters, of which the only fact was `Leader: Player N`. Every alliance and every betrayal across 100 games was decided **without seeing the map**.

The test that should have caught this **was complicit**: its fixture invented the shape the renderer expected, so the two agreed with each other and neither agreed with reality. The fixture now takes its observation straight from `RisikoEnv`.

**The prompt budget dropped the wrong half.** The first pass at the board summary blew the 640-char cap and the trailing slice ate the Diplomacy block mid-word. Diplomacy is now reserved; the board sheds whole lines.

**`strategies.py` claimed to be "research-grounded" with no citation.** The six strategies do come from the mainstream Risk literature; the sources are now in the module — along with the caveat that the models were trained on that same literature, so "the Australia lock underperforms" may say as much about what they have *read* as about the board.

## Verification

- Full suite green, ruff clean.
- 9 new tests in `tests/test_seat_confound.py`, each documenting *why* it exists — these are bugs that produce perfectly healthy-looking numbers.
- Tournament restarted from zero (`tourney_v2`): the first of three runs whose numbers can actually be interpreted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)